### PR TITLE
Update showcase IR fixture to use loop node and nested schemas

### DIFF
--- a/packages/ir/fixtures/showcase-all-nodes.ir.json
+++ b/packages/ir/fixtures/showcase-all-nodes.ir.json
@@ -1,13 +1,21 @@
 {
   "irVersion": "0.1.0",
   "name": "showcase_all_nodes",
-  "description": "End-to-end article pipeline that exercises every IR node type in one functional graph: START → ask_topic (humanInput) → fetch_article (tool, emits a structured Article) → summarize (agent, consumes Article via a prompt var) → expand_sections (nested workflow: parallel function fan-out → join → function) → classify (router) → {publish (function), request_revision (agent)}. The router branches are terminal and the join lives inside the nested workflow, since a router picks one branch while a join waits for all upstreams.",
+  "description": "End-to-end article pipeline that exercises every IR node type in one functional graph: START → ask_topic (humanInput) → fetch_article (tool, emits a structured Article) → summarize (agent, consumes Article via a prompt var) → expand_sections (nested workflow: parallel function fan-out → join → function) → refine_loop (loop: generate→critic→revise until approved, ADR-0039) → classify (router) → {publish (function), request_revision (agent)}. Also exercises nested pydantic models (ADR-0037): Article embeds an Author and is declared before Author, so schemas.py must emit Author first via topological order. The router branches are terminal and the join lives inside the nested workflow, since a router picks one branch while a join waits for all upstreams.",
   "schemas": [
     {
       "name": "Article",
       "fields": [
         { "name": "title", "type": "str" },
-        { "name": "body", "type": "str" }
+        { "name": "body", "type": "str" },
+        { "name": "author", "type": "Author" }
+      ]
+    },
+    {
+      "name": "Author",
+      "fields": [
+        { "name": "name", "type": "str" },
+        { "name": "email", "type": "str" }
       ]
     }
   ],
@@ -143,10 +151,35 @@
       }
     },
     {
+      "id": "n_refine_loop",
+      "type": "loop",
+      "name": "refine_loop",
+      "ui": { "x": 1040, "y": 0 },
+      "config": {
+        "description": "Refine the assembled draft: generate→critic→revise until the critic approves, contained in a single @node orchestrator.",
+        "maxIterations": 4,
+        "approvalPhrase": "APPROVED",
+        "inputType": "str",
+        "payloadType": "Article",
+        "generator": {
+          "model": "gemini-2.5-flash",
+          "instruction": "You are a senior editor. Turn the assembled draft into a polished Article with a title, body, and author."
+        },
+        "critic": {
+          "model": "gemini-2.5-flash",
+          "instruction": "Review the Article against editorial standards. If it is publication-ready, return status 'APPROVED'. Otherwise, return specific, actionable feedback."
+        },
+        "reviser": {
+          "model": "gemini-2.5-pro",
+          "instruction": "Revise the Article to address the critic's feedback while preserving its intent."
+        }
+      }
+    },
+    {
       "id": "n_classify",
       "type": "router",
       "name": "classify",
-      "ui": { "x": 1040, "y": 0 },
+      "ui": { "x": 1300, "y": 0 },
       "config": {
         "description": "Decide whether the assembled draft is ready to publish or needs revision.",
         "routes": ["PUBLISH", "REVISE"],
@@ -158,7 +191,7 @@
       "id": "n_publish",
       "type": "function",
       "name": "publish",
-      "ui": { "x": 1300, "y": -80 },
+      "ui": { "x": 1560, "y": -80 },
       "config": {
         "description": "Publish the finished article.",
         "inputType": "str",
@@ -171,7 +204,7 @@
       "id": "n_request_revision",
       "type": "agent",
       "name": "request_revision",
-      "ui": { "x": 1300, "y": 80 },
+      "ui": { "x": 1560, "y": 80 },
       "config": {
         "model": "gemini-flash-latest",
         "instruction": {
@@ -190,7 +223,8 @@
     { "from": "n_ask_topic", "to": "n_fetch_article" },
     { "from": "n_fetch_article", "to": "n_summarize" },
     { "from": "n_summarize", "to": "n_expand" },
-    { "from": "n_expand", "to": "n_classify" },
+    { "from": "n_expand", "to": "n_refine_loop" },
+    { "from": "n_refine_loop", "to": "n_classify" },
     { "from": "n_classify", "to": "n_publish", "route": "PUBLISH" },
     { "from": "n_classify", "to": "n_request_revision", "route": "REVISE" }
   ]


### PR DESCRIPTION
## What

Updates `packages/ir/fixtures/showcase-all-nodes.ir.json` to use the two IR features added since it first landed (PR #1), keeping it the single comprehensive example.

- **`loop` node (ADR-0039):** a `refine_loop` generate→critic→revise node spliced between the nested workflow and the router. The showcase now exercises **all 8 node types**.
- **Nested pydantic models (ADR-0037):** `Article` now embeds an `Author`, and is declared **before** `Author` in the array — so `schemas.py` must emit `Author` first via topological order.

## Updated topology

```
START → ask_topic (humanInput)
      → fetch_article (tool, emits structured Article)
      → summarize (agent, consumes Article via prompt var <Article.body from fetch_article>)
      → expand_sections (workflow — nested parallel fan-out → join → function)
      → refine_loop (loop — generate→critic→revise until "APPROVED")   ← new
      → classify (router) ─ PUBLISH → publish (function)
                          └ REVISE  → request_revision (agent)
```

## Verification

- `npm run check:ir` — `PASS … showcase-all-nodes.ir.json (8 nodes, 8 edges, 2 schemas)`
- `npm test` — full gate green (**102/102**); the existing showcase assertion still holds (zero errors, zero warnings)
- Codegen compile of the fixture now emits `loops.py` (containing `refine_loop_orchestrator`), and `schemas.py` orders `Author` before `Article`

https://claude.ai/code/session_01LkqTMAEbRnNaGcbpJNfzym

---
_Generated by [Claude Code](https://claude.ai/code/session_01LkqTMAEbRnNaGcbpJNfzym)_