### PR TITLE
Make nested workflows editable: zoom-into-sub-graph navigation (ADR-0050)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,5 +1,6 @@
 import { AnimatePresence, LazyMotion, MotionConfig, domMax, m } from "motion/react";
 import { Canvas } from "./canvas/Canvas.tsx";
+import { SubgraphBreadcrumb } from "./canvas/SubgraphBreadcrumb.tsx";
 import { Inspector } from "./inspector/Inspector.tsx";
 import { Landing } from "./landing/Landing.tsx";
 import { Palette } from "./palette/Palette.tsx";
@@ -53,6 +54,7 @@ function Workbench() {
         <PaneResizeHandle pane="left" edge="end" />
         <m.section className="pane pane--canvas" variants={paneItem}>
           <header>Canvas</header>
+          <SubgraphBreadcrumb />
           <Canvas />
         </m.section>
         <PaneResizeHandle pane="inspector" edge="start" />

--- a/apps/web/src/canvas/Canvas.tsx
+++ b/apps/web/src/canvas/Canvas.tsx
@@ -12,6 +12,7 @@ import {
   type ReactFlowInstance,
 } from "@xyflow/react";
 import { useIRStore } from "../store/irStore.ts";
+import { selectActiveGraph } from "../store/subgraph.ts";
 import { IRNode, type IRNodeData } from "./IRNode.tsx";
 import { StartNode } from "./StartNode.tsx";
 import { CanvasEmptyState } from "./CanvasEmptyState.tsx";
@@ -51,7 +52,13 @@ function startNodePosition(nodes: { ui?: { x: number; y: number } }[]): {
 }
 
 export function Canvas() {
-  const ir = useIRStore((s) => s.ir);
+  // The canvas projects the *active* graph (ADR-0050): the root, or the
+  // sub-graph of the workflow node the user zoomed into. Sub-graphs are
+  // complete IRs with their own START edges and ui positions, so the
+  // projection below works unchanged at any depth.
+  const graph = useIRStore(selectActiveGraph);
+  const subgraphPath = useIRStore((s) => s.subgraphPath);
+  const enterSubgraph = useIRStore((s) => s.enterSubgraph);
   // Grid colors come from the theme registry, not CSS — React Flow's
   // <Background color> lands on SVG presentation attributes, which don't
   // resolve var() (ADR-0044).
@@ -79,15 +86,36 @@ export function Canvas() {
   // instance or node is missing; `measured` is undefined before first layout,
   // so fall back to nominal half-extents. Cannot loop: `focusRequest` only
   // changes on a finding click, and `setCenter` never writes the store.
+  // When `focusFinding` also switched the sub-graph (ADR-0050), React Flow
+  // may not have ingested the new `nodes` prop yet — retry once on the next
+  // frame before giving up.
   const focusRequest = useIRStore((s) => s.focusRequest);
   useEffect(() => {
-    if (!focusRequest || !rfInstance.current) return;
-    const node = rfInstance.current.getNode(focusRequest.nodeId);
-    if (!node) return;
-    const cx = node.position.x + (node.measured?.width ?? 180) / 2;
-    const cy = node.position.y + (node.measured?.height ?? 60) / 2;
-    void rfInstance.current.setCenter(cx, cy, { duration: 300 });
+    if (!focusRequest) return;
+    const center = (retry: boolean): void => {
+      const inst = rfInstance.current;
+      if (!inst) return;
+      const node = inst.getNode(focusRequest.nodeId);
+      if (!node) {
+        if (retry) requestAnimationFrame(() => center(false));
+        return;
+      }
+      const cx = node.position.x + (node.measured?.width ?? 180) / 2;
+      const cy = node.position.y + (node.measured?.height ?? 60) / 2;
+      void inst.setCenter(cx, cy, { duration: 300 });
+    };
+    center(true);
   }, [focusRequest]);
+
+  // Re-frame the viewport when navigating between graphs (zoom in via
+  // double-click / breadcrumb jump back out). rAF: React Flow ingests the
+  // new `nodes` prop in its own effect, so fitting synchronously would frame
+  // the *previous* graph. Best-effort, same posture as ADR-0043.
+  useEffect(() => {
+    requestAnimationFrame(() => {
+      void rfInstance.current?.fitView({ duration: 300 });
+    });
+  }, [subgraphPath]);
 
   // Map IR nodes to React Flow nodes, prepending the synthetic START node
   // so users can drag from it like any other source handle (ADR-0026).
@@ -98,13 +126,13 @@ export function Canvas() {
     const start: RFNode = {
       id: START_NODE_ID,
       type: "ir-start",
-      position: startNodePosition(ir.nodes),
+      position: startNodePosition(graph.nodes),
       data: {},
       deletable: false,
       selectable: false,
       draggable: false,
     };
-    const rest: RFNode<IRNodeData>[] = ir.nodes.map((n) => ({
+    const rest: RFNode<IRNodeData>[] = graph.nodes.map((n) => ({
       id: n.id,
       type: "ir",
       position: { x: n.ui?.x ?? 0, y: n.ui?.y ?? 0 },
@@ -112,7 +140,7 @@ export function Canvas() {
       data: { node: n, selected: n.id === selectedNodeId },
     }));
     return [start, ...rest];
-  }, [ir.nodes, selectedNodeId]);
+  }, [graph.nodes, selectedNodeId]);
 
   // Every IR edge — including START edges — becomes a React Flow edge now
   // that START is a real (synthetic) node. `selected` drives RF's Delete
@@ -120,7 +148,7 @@ export function Canvas() {
   // selection-bridge round-trips back to the right IR edge (ADR-0027).
   const rfEdges: RFEdge[] = useMemo(
     () =>
-      ir.edges.map((e) => {
+      graph.edges.map((e) => {
         const id = edgeId(e.from, e.to, e.route);
         const isSelected =
           selectedEdge !== null &&
@@ -135,7 +163,7 @@ export function Canvas() {
           selected: isSelected,
         };
       }),
-    [ir.edges, selectedEdge],
+    [graph.edges, selectedEdge],
   );
 
   // Resolve an RF edge id back to the IR edge triple. Necessary because
@@ -143,9 +171,9 @@ export function Canvas() {
   // dispatch into the store.
   const edgeByRFId = useMemo(() => {
     const m = new Map<string, { from: string; to: string; route?: string }>();
-    for (const e of ir.edges) m.set(edgeId(e.from, e.to, e.route), e);
+    for (const e of graph.edges) m.set(edgeId(e.from, e.to, e.route), e);
     return m;
-  }, [ir.edges]);
+  }, [graph.edges]);
 
   // Bridge React Flow's internal selection + drag events back into our
   // store. `select` events drive node selection (and React Flow's Delete
@@ -195,7 +223,7 @@ export function Canvas() {
     // routes (the validator would already be flagging ROUTER_NO_ROUTES),
     // leave the edge unlabeled and surface ROUTER_UNLABELED_EDGE honestly
     // (ADR-0027, follows ADR-0026's honest-surface posture).
-    const source = ir.nodes.find((n) => n.id === conn.source);
+    const source = graph.nodes.find((n) => n.id === conn.source);
     const route =
       source?.type === "router" ? source.config.routes[0] : undefined;
     connectEdge(conn.source, conn.target, route);
@@ -236,6 +264,12 @@ export function Canvas() {
         if (n.id === START_NODE_ID) return;
         setSelectedNode(n.id);
       }}
+      onNodeDoubleClick={(_e, n) => {
+        // Zoom into a workflow node's sub-graph (ADR-0050). The Inspector's
+        // "Open sub-graph" button is the discoverable alternative.
+        const irNode = graph.nodes.find((x) => x.id === n.id);
+        if (irNode?.type === "workflow") enterSubgraph(irNode.id);
+      }}
       onPaneClick={() => {
         setSelectedNode(null);
         setSelectedEdge(null);
@@ -275,7 +309,16 @@ export function Canvas() {
       />
       <Controls />
     </ReactFlow>
-    {ir.nodes.length === 0 && <CanvasEmptyState />}
+    {/* The example-loading empty state swaps the whole IR (`replaceIR`), so
+        it only belongs at the root; an emptied sub-graph gets a hint. */}
+    {graph.nodes.length === 0 &&
+      (subgraphPath.length === 0 ? (
+        <CanvasEmptyState />
+      ) : (
+        <div className="canvas-empty-subgraph">
+          Empty sub-graph — add nodes from the palette.
+        </div>
+      ))}
     </div>
   );
 }

--- a/apps/web/src/canvas/SubgraphBreadcrumb.tsx
+++ b/apps/web/src/canvas/SubgraphBreadcrumb.tsx
@@ -1,0 +1,58 @@
+/**
+ * Breadcrumb bar for nested workflow editing (ADR-0050). Renders nothing at
+ * the root; while zoomed into a sub-graph it shows the path from the root IR
+ * through every workflow node, with each ancestor segment clickable to jump
+ * back out. The last segment is the graph currently on the canvas.
+ */
+import { useIRStore } from "../store/irStore.ts";
+import { breadcrumbItems } from "../store/subgraph.ts";
+
+export function SubgraphBreadcrumb() {
+  const ir = useIRStore((s) => s.ir);
+  const subgraphPath = useIRStore((s) => s.subgraphPath);
+  const setSubgraphPath = useIRStore((s) => s.setSubgraphPath);
+
+  if (subgraphPath.length === 0) return null;
+  // A transiently invalid path renders nothing; the canvas already falls
+  // back to the root via `selectActiveGraph`.
+  const items = breadcrumbItems(ir, subgraphPath);
+  if (!items) return null;
+
+  return (
+    <nav className="subgraph-breadcrumb" aria-label="Sub-graph location">
+      <button
+        type="button"
+        className="subgraph-breadcrumb__segment"
+        onClick={() => setSubgraphPath([])}
+      >
+        {ir.name}
+      </button>
+      {items.map((item, i) => {
+        const isCurrent = i === items.length - 1;
+        return (
+          <span key={item.id} className="subgraph-breadcrumb__crumb">
+            <span className="subgraph-breadcrumb__sep" aria-hidden="true">
+              ›
+            </span>
+            {isCurrent ? (
+              <span
+                className="subgraph-breadcrumb__segment subgraph-breadcrumb__segment--current"
+                aria-current="location"
+              >
+                {item.name}
+              </span>
+            ) : (
+              <button
+                type="button"
+                className="subgraph-breadcrumb__segment"
+                onClick={() => setSubgraphPath(subgraphPath.slice(0, i + 1))}
+              >
+                {item.name}
+              </button>
+            )}
+          </span>
+        );
+      })}
+    </nav>
+  );
+}

--- a/apps/web/src/inspector/Inspector.tsx
+++ b/apps/web/src/inspector/Inspector.tsx
@@ -23,6 +23,7 @@ import type {
 import { useRef, useState, type ReactNode } from "react";
 import { AnimatePresence, m } from "motion/react";
 import { useIRStore } from "../store/irStore.ts";
+import { selectActiveGraph } from "../store/subgraph.ts";
 import type { ModelParamKey } from "../store/irReducer.ts";
 import { formSwap } from "../anim/presets.ts";
 import { VariableEditor, type VariableEditorAPI } from "./VariableEditor.tsx";
@@ -250,7 +251,7 @@ function Header({ node }: { node: GraphNode }) {
 function AgentForm({ node }: { node: AgentNode }) {
   const updateNodeConfig = useIRStore((s) => s.updateNodeConfig);
   const updateModelParam = useIRStore((s) => s.updateModelParam);
-  const schemas = useIRStore((s) => s.ir.schemas).map((x) => x.name);
+  const schemas = useIRStore((s) => selectActiveGraph(s).schemas).map((x) => x.name);
   const params = node.config.modelParams ?? {};
 
   // Imperative handle into the Lexical editor for chip insertion (ADR-0030).
@@ -395,7 +396,7 @@ function AgentForm({ node }: { node: AgentNode }) {
 
 function FunctionForm({ node }: { node: FunctionNode }) {
   const updateNodeConfig = useIRStore((s) => s.updateNodeConfig);
-  const schemas = useIRStore((s) => s.ir.schemas).map((x) => x.name);
+  const schemas = useIRStore((s) => selectActiveGraph(s).schemas).map((x) => x.name);
   return (
     <div>
       <Header node={node} />
@@ -462,7 +463,7 @@ function FunctionForm({ node }: { node: FunctionNode }) {
 
 function ToolForm({ node }: { node: ToolNode }) {
   const updateNodeConfig = useIRStore((s) => s.updateNodeConfig);
-  const schemas = useIRStore((s) => s.ir.schemas).map((x) => x.name);
+  const schemas = useIRStore((s) => selectActiveGraph(s).schemas).map((x) => x.name);
   return (
     <div>
       <Header node={node} />
@@ -514,7 +515,7 @@ function ToolForm({ node }: { node: ToolNode }) {
 
 function RouterForm({ node }: { node: RouterNode }) {
   const updateNodeConfig = useIRStore((s) => s.updateNodeConfig);
-  const schemas = useIRStore((s) => s.ir.schemas).map((x) => x.name);
+  const schemas = useIRStore((s) => selectActiveGraph(s).schemas).map((x) => x.name);
   return (
     <div>
       <Header node={node} />
@@ -593,7 +594,7 @@ function JoinForm({ node }: { node: JoinNode }) {
 
 function HumanInputForm({ node }: { node: HumanInputNode }) {
   const updateNodeConfig = useIRStore((s) => s.updateNodeConfig);
-  const schemas = useIRStore((s) => s.ir.schemas).map((x) => x.name);
+  const schemas = useIRStore((s) => selectActiveGraph(s).schemas).map((x) => x.name);
   return (
     <div>
       <Header node={node} />
@@ -638,6 +639,7 @@ function HumanInputForm({ node }: { node: HumanInputNode }) {
 
 function WorkflowForm({ node }: { node: WorkflowNode }) {
   const updateNodeConfig = useIRStore((s) => s.updateNodeConfig);
+  const enterSubgraph = useIRStore((s) => s.enterSubgraph);
   const sub: GraphIR | undefined = node.config.graph;
   const nodeCount = Array.isArray(sub?.nodes) ? sub.nodes.length : 0;
   return (
@@ -659,9 +661,20 @@ function WorkflowForm({ node }: { node: WorkflowNode }) {
       </div>
       <div className="field">
         <label>graph</label>
+        {/* Discoverable alternative to double-clicking the canvas card
+            (ADR-0050). The selected node is in the active graph by
+            definition, so enterSubgraph always resolves. */}
+        <button
+          type="button"
+          className="open-subgraph"
+          onClick={() => enterSubgraph(node.id)}
+        >
+          Open sub-graph ({nodeCount} node{nodeCount === 1 ? "" : "s"})
+        </button>
         <div className="field__hint">
-          Nested workflow: {nodeCount} node{nodeCount === 1 ? "" : "s"} —
-          sub-graph editing in a later slice.
+          Edits the nested workflow on the canvas — double-clicking the node
+          card does the same. Use the breadcrumb above the canvas to come
+          back.
         </div>
       </div>
       </FormSection>
@@ -682,7 +695,7 @@ function WorkflowForm({ node }: { node: WorkflowNode }) {
  */
 function LoopForm({ node }: { node: LoopNode }) {
   const updateNodeConfig = useIRStore((s) => s.updateNodeConfig);
-  const schemas = useIRStore((s) => s.ir.schemas).map((x) => x.name);
+  const schemas = useIRStore((s) => selectActiveGraph(s).schemas).map((x) => x.name);
   const cfg = node.config;
 
   const subAgentRow = (
@@ -794,10 +807,10 @@ function LoopForm({ node }: { node: LoopNode }) {
 function EdgeForm() {
   const selectedEdge = useIRStore((s) => s.selectedEdge)!;
   const sourceNode = useIRStore((s) =>
-    s.ir.nodes.find((n) => n.id === selectedEdge.from),
+    selectActiveGraph(s).nodes.find((n) => n.id === selectedEdge.from),
   );
   const targetNode = useIRStore((s) =>
-    s.ir.nodes.find((n) => n.id === selectedEdge.to),
+    selectActiveGraph(s).nodes.find((n) => n.id === selectedEdge.to),
   );
   const setEdgeRoute = useIRStore((s) => s.setEdgeRoute);
 
@@ -893,9 +906,15 @@ function formFor(node: NonNullable<ReturnType<typeof pickNode>>): ReactNode {
   }
 }
 
-function pickNode(s: { selectedNodeId: string | null; ir: GraphIR }) {
+function pickNode(s: {
+  selectedNodeId: string | null;
+  ir: GraphIR;
+  subgraphPath: string[];
+}) {
+  // Selection is scoped to the active graph (ADR-0050): the same id could
+  // legally recur in a nested sub-graph of a hand-loaded IR.
   return s.selectedNodeId
-    ? s.ir.nodes.find((n) => n.id === s.selectedNodeId) ?? null
+    ? selectActiveGraph(s).nodes.find((n) => n.id === s.selectedNodeId) ?? null
     : null;
 }
 

--- a/apps/web/src/inspector/VariablePalette.tsx
+++ b/apps/web/src/inspector/VariablePalette.tsx
@@ -14,6 +14,7 @@
 import type { CSSProperties } from "react";
 import type { AgentNode } from "@graphical-agents/ir";
 import { useIRStore } from "../store/irStore.ts";
+import { selectActiveGraph } from "../store/subgraph.ts";
 import {
   candidateVariables,
   chipSchemas,
@@ -57,7 +58,10 @@ export interface VariablePaletteProps {
 }
 
 export function VariablePalette({ agent, onInsert }: VariablePaletteProps) {
-  const ir = useIRStore((s) => s.ir);
+  // Candidates come from the *active* graph (ADR-0050): the validator
+  // resolves var-segment sources strictly per-level, so only producers in
+  // the agent's own graph are legal.
+  const ir = useIRStore(selectActiveGraph);
   const candidates = candidateVariables(ir, agent.id);
   const locked = chipSchemas(agent);
   const lockedSchema = locked.size === 1 ? [...locked][0] : undefined;

--- a/apps/web/src/preview/Preview.tsx
+++ b/apps/web/src/preview/Preview.tsx
@@ -8,7 +8,7 @@ import { useIRStore } from "../store/irStore.ts";
 // compile path; black formatting is opt-in and lives in later slices.
 import { compile, ValidationError } from "../../../../packages/codegen/src/compile.ts";
 import type { GeneratedProject } from "../../../../packages/codegen/src/project.ts";
-import { resolveFindingTarget } from "../store/findingTarget.ts";
+import { resolveFindingPath } from "../store/subgraph.ts";
 import { EASE_OUT, findingItem } from "../anim/presets.ts";
 import type { CodegenTarget } from "../target/targets.ts";
 import { useTargetStore } from "../target/targetStore.ts";
@@ -40,7 +40,7 @@ const DEFAULT_FILE = "agents.py";
  */
 function Findings({ findings }: { findings: ValidationError["findings"] }) {
   const ir = useIRStore((s) => s.ir);
-  const focusNode = useIRStore((s) => s.focusNode);
+  const focusFinding = useIRStore((s) => s.focusFinding);
 
   // Stable per-finding keys; duplicates (same code+node+message) get a
   // disambiguating counter so React keys stay unique.
@@ -64,7 +64,11 @@ function Findings({ findings }: { findings: ValidationError["findings"] }) {
       <ul className="findings">
         <AnimatePresence mode="popLayout" initial={false}>
           {rows.map(({ f, key }) => {
-            const target = resolveFindingTarget(f.nodeId, ir);
+            // Path-prefixed nested ids ("n_outer/n_inner", ADR-0017)
+            // navigate into the owning sub-graph and center the actual
+            // node, instead of landing on the enclosing workflow card
+            // (ADR-0050).
+            const target = resolveFindingPath(ir, f.nodeId);
             const body = (
               <>
                 <span className="finding-row__dot" aria-hidden="true" />
@@ -90,7 +94,7 @@ function Findings({ findings }: { findings: ValidationError["findings"] }) {
                     type="button"
                     className="finding-row__btn"
                     title="Show this node on the canvas"
-                    onClick={() => focusNode(target)}
+                    onClick={() => focusFinding(f.nodeId!)}
                   >
                     {body}
                   </button>

--- a/apps/web/src/schemas/SchemaPanel.tsx
+++ b/apps/web/src/schemas/SchemaPanel.tsx
@@ -13,6 +13,7 @@ import { useState } from "react";
 import type { CSSProperties } from "react";
 import type { SchemaDef, SchemaField } from "@graphical-agents/ir";
 import { useIRStore } from "../store/irStore.ts";
+import { breadcrumbItems, selectActiveGraph } from "../store/subgraph.ts";
 import { fieldTypeCandidates, scalarTypes } from "../store/schemas.ts";
 
 const ROW: CSSProperties = { marginBottom: 8 };
@@ -58,7 +59,7 @@ function FieldRow({
   schemaName: string;
   field: SchemaField;
 }) {
-  const schemas = useIRStore((s) => s.ir.schemas);
+  const schemas = useIRStore((s) => selectActiveGraph(s).schemas);
   const updateField = useIRStore((s) => s.updateField);
   const deleteField = useIRStore((s) => s.deleteField);
   // Scalars stay listed under the `scalar` group; foreign schema names appear
@@ -160,10 +161,24 @@ function SchemaCard({ schema }: { schema: SchemaDef }) {
 }
 
 export function SchemaPanel() {
-  const schemas = useIRStore((s) => s.ir.schemas);
+  // The panel edits the *active* graph's schemas (ADR-0050): schema refs
+  // resolve strictly per-level in the validator, so these are the only
+  // legal ref targets for the nodes on the canvas.
+  const schemas = useIRStore((s) => selectActiveGraph(s).schemas);
+  const subgraphPath = useIRStore((s) => s.subgraphPath);
+  const scopeName = useIRStore((s) =>
+    s.subgraphPath.length === 0
+      ? null
+      : breadcrumbItems(s.ir, s.subgraphPath)?.at(-1)?.name ?? null,
+  );
   const addSchema = useIRStore((s) => s.addSchema);
   return (
     <div className="schema-panel">
+      {scopeName !== null && (
+        <div className="schema-scope">
+          schemas of <strong>{scopeName}</strong>
+        </div>
+      )}
       <div style={ROW}>
         <button type="button" className="schema-add" onClick={() => addSchema()}>
           + Schema
@@ -171,8 +186,11 @@ export function SchemaPanel() {
       </div>
       {schemas.length === 0 ? (
         <div className="schema-empty">
-          No schemas. Add one to make its fields available as variable chips on
-          downstream agents.
+          {subgraphPath.length === 0
+            ? "No schemas. Add one to make its fields available as variable " +
+              "chips on downstream agents."
+            : "No schemas in this sub-graph. Nested nodes can only reference " +
+              "schemas declared at their own level."}
         </div>
       ) : (
         <div className="schema-list">

--- a/apps/web/src/store/addNode.ts
+++ b/apps/web/src/store/addNode.ts
@@ -28,6 +28,7 @@ import type {
   UiPosition,
   WorkflowNode,
 } from "@graphical-agents/ir";
+import { graphAtPath, updateGraphAtPath } from "./subgraph.ts";
 
 export type AddableNodeType = NodeType;
 
@@ -280,22 +281,48 @@ function makeDefaultNode(
 }
 
 /**
- * Add a new node of `type` to `ir`. Returns a new IR and the minted node id
- * so the store can select it without re-deriving. Pure: `ir` is untouched.
+ * Add a new node of `type` to the graph at `path` inside `root` (ADR-0050).
+ * Id and name are minted against the **root** — the flat global namespace
+ * spans every nesting level (ADR-0017) — but the staggered default position
+ * is computed against the **target graph**, so the node lands in the canvas
+ * the user is looking at. `root` is also what `minimalSubIR` reserves names
+ * against when adding a workflow-inside-a-workflow.
+ *
+ * No-op (same `ir` reference, empty `nodeId`) when `path` doesn't resolve.
+ * Pure: `root` is untouched.
+ */
+export function addNodeAt(
+  root: GraphIR,
+  path: readonly string[],
+  type: AddableNodeType,
+  position?: UiPosition,
+): { ir: GraphIR; nodeId: string } {
+  const target = graphAtPath(root, path);
+  if (!target) return { ir: root, nodeId: "" };
+  const id = makeNodeId(root, type);
+  const name = makeNodeName(root, type);
+  // Explicit position (drag-and-drop drop point, ADR-0034) wins; otherwise
+  // fall back to the staggered default used by click-to-add.
+  const ui = position ?? defaultPositionFor(target);
+  const node = makeDefaultNode(root, type, id, name, ui);
+  return {
+    ir: updateGraphAtPath(root, path, (g) => ({
+      ...g,
+      nodes: [...g.nodes, node],
+    })),
+    nodeId: id,
+  };
+}
+
+/**
+ * Add a new node of `type` to `ir` (top level). Returns a new IR and the
+ * minted node id so the store can select it without re-deriving. Pure:
+ * `ir` is untouched.
  */
 export function addNode(
   ir: GraphIR,
   type: AddableNodeType,
   position?: UiPosition,
 ): { ir: GraphIR; nodeId: string } {
-  const id = makeNodeId(ir, type);
-  const name = makeNodeName(ir, type);
-  // Explicit position (drag-and-drop drop point, ADR-0034) wins; otherwise
-  // fall back to the staggered default used by click-to-add.
-  const ui = position ?? defaultPositionFor(ir);
-  const node = makeDefaultNode(ir, type, id, name, ui);
-  return {
-    ir: { ...ir, nodes: [...ir.nodes, node] },
-    nodeId: id,
-  };
+  return addNodeAt(ir, [], type, position);
 }

--- a/apps/web/src/store/findingTarget.ts
+++ b/apps/web/src/store/findingTarget.ts
@@ -9,6 +9,11 @@
  * shows the nested graph's summary there).
  *
  * No DOM, no zustand — headlessly tested in `test/findingTarget.test.ts`.
+ *
+ * Superseded for the Preview click path by `subgraph.ts`'s
+ * `resolveFindingPath` (ADR-0050), which navigates *into* the owning
+ * sub-graph instead of collapsing to the top-level workflow node. Kept as
+ * the documented top-level-only resolver.
  */
 import type { GraphIR } from "@graphical-agents/ir";
 

--- a/apps/web/src/store/irEdges.ts
+++ b/apps/web/src/store/irEdges.ts
@@ -85,9 +85,10 @@ export function setEdgeRoute(
 }
 
 /**
- * Remove `nodeId` from the top-level graph and every edge that references
- * it (as `from` or `to`). No-op (same IR reference) if `nodeId` is not a
- * top-level node — nested-graph editing is a later slice.
+ * Remove `nodeId` from this graph and every edge that references it (as
+ * `from` or `to`). No-op (same IR reference) if `nodeId` is not a node of
+ * this graph — the store retargets the reducer at the active sub-graph via
+ * `updateGraphAtPath` (ADR-0050).
  */
 export function deleteNode(ir: GraphIR, nodeId: string): GraphIR {
   if (!ir.nodes.some((n) => n.id === nodeId)) return ir;

--- a/apps/web/src/store/irReducer.ts
+++ b/apps/web/src/store/irReducer.ts
@@ -13,6 +13,7 @@ import type {
   GraphNode,
   InstructionSegment,
 } from "@graphical-agents/ir";
+import { graphAtPath, updateGraphAtPath } from "./subgraph.ts";
 
 /** Shallow-merge `patch` into the named node's `config`, returning a new IR. */
 export function applyNodeConfigPatch(
@@ -85,9 +86,10 @@ export function applyNodePosition(
 }
 
 /**
- * Rename a top-level node AND cascade every top-level reference to the old
- * name. Node analog of `renameSchema` (ADR-0035): without the cascade a single
- * rename click would silently break codegen — the var-chip source binding
+ * Rename the node `nodeId` in the graph at `path` AND cascade every
+ * reference to the old name across **all** nesting levels (ADR-0050). Node
+ * analog of `renameSchema` (ADR-0035): without the cascade a single rename
+ * click would silently break codegen — the var-chip source binding
  * `<Schema.field from name>` (IR-SCHEMA invariant 1) and an agent's
  * `config.tools[]` both address other nodes by `name`.
  *
@@ -95,42 +97,85 @@ export function applyNodePosition(
  *   - var-segment `source` in every agent's `instruction.segments`
  *   - every entry of every agent's `config.tools[]`
  *
+ * The cascade recurses through every `workflow.config.graph`. Var sources
+ * only resolve per-level in the validator, but `tools[]` entries resolve
+ * globally by name; node names are globally unique (ADR-0017), so a
+ * tree-wide cascade is correct for both and needs no scoping logic.
+ *
+ * The rename itself is path-scoped (never "find this id anywhere"): node ids
+ * are only conventionally global, so a hand-loaded IR may reuse an id across
+ * levels.
+ *
  * Edges are NOT touched: `Edge.from` / `Edge.to` carry node `id`s, not names.
  *
- * No-op (returns the input IR ref) when `nodeId` doesn't name a top-level node
- * or `newName === oldName`. Identifier validity / uniqueness is NOT
- * re-implemented here — invariant 1 lives in `validate.ts` and Preview
- * surfaces `INVALID_NODE_NAME` / `DUPLICATE_NODE_NAME` honestly
+ * No-op (returns the input IR ref) when `path` doesn't resolve, `nodeId`
+ * isn't in that graph, or `newName === oldName`. Identifier validity /
+ * uniqueness is NOT re-implemented here — invariant 1 lives in `validate.ts`
+ * and Preview surfaces `INVALID_NODE_NAME` / `DUPLICATE_NODE_NAME` honestly
  * (ADR-0023 mirror-the-validator posture).
- *
- * Top-level only: nested `workflow.config.graph.nodes` are out of scope,
- * consistent with the nested-graph editing deferral across
- * ADR-0017 / ADR-0023 / ADR-0026 / ADR-0029 / ADR-0035. When sub-graph editing
- * lands, the cascade will need to recurse (or the sub-graph slice picks it up
- * as a sibling concern).
  *
  * Pure: new IR, original untouched, unaffected sibling nodes preserve
  * referential identity so React Flow doesn't re-render unrelated cards.
  */
+export function renameNodeAt(
+  ir: GraphIR,
+  path: readonly string[],
+  nodeId: string,
+  newName: string,
+): GraphIR {
+  const graph = graphAtPath(ir, path);
+  if (!graph) return ir;
+  const target = graph.nodes.find((n) => n.id === nodeId);
+  if (!target) return ir;
+  const oldName = target.name;
+  if (newName === oldName) return ir;
+
+  // Pass 1: rename the target node, path-scoped.
+  const renamed = updateGraphAtPath(ir, path, (g) => ({
+    ...g,
+    nodes: g.nodes.map((n): GraphNode =>
+      n.id === nodeId ? ({ ...n, name: newName } as GraphNode) : n,
+    ),
+  }));
+
+  // Pass 2: cascade references across every level. The renamed node itself
+  // no longer carries `oldName`, so the cascade can't touch it.
+  return cascadeGraph(renamed, oldName, newName);
+}
+
+/** Back-compat top-level entry point: `renameNodeAt` with the root path. */
 export function renameNode(
   ir: GraphIR,
   nodeId: string,
   newName: string,
 ): GraphIR {
-  const target = ir.nodes.find((n) => n.id === nodeId);
-  if (!target) return ir;
-  const oldName = target.name;
-  if (newName === oldName) return ir;
+  return renameNodeAt(ir, [], nodeId, newName);
+}
 
-  const nodes = ir.nodes.map((n): GraphNode => {
-    if (n.id === nodeId) {
-      return { ...n, name: newName } as GraphNode;
+/**
+ * Apply `cascadeAgent` to every agent at every nesting level. Same-reference
+ * no-op discipline throughout so untouched graphs and nodes keep referential
+ * identity.
+ */
+function cascadeGraph(g: GraphIR, oldName: string, newName: string): GraphIR {
+  let changed = false;
+  const nodes = g.nodes.map((n): GraphNode => {
+    if (n.type === "agent") {
+      const next = cascadeAgent(n as AgentNode, oldName, newName);
+      if (next !== n) changed = true;
+      return next;
     }
-    if (n.type !== "agent") return n;
-    return cascadeAgent(n as AgentNode, oldName, newName);
+    if (n.type === "workflow") {
+      const nextSub = cascadeGraph(n.config.graph, oldName, newName);
+      if (nextSub !== n.config.graph) {
+        changed = true;
+        return { ...n, config: { ...n.config, graph: nextSub } };
+      }
+      return n;
+    }
+    return n;
   });
-
-  return { ...ir, nodes };
+  return changed ? { ...g, nodes } : g;
 }
 
 function cascadeAgent(

--- a/apps/web/src/store/irStore.ts
+++ b/apps/web/src/store/irStore.ts
@@ -17,10 +17,16 @@ import {
   applyNodeConfigPatch,
   applyNodePosition,
   cloneFixture,
-  renameNode as renameNodeReducer,
+  renameNodeAt as renameNodeAtReducer,
   type ModelParamKey,
 } from "./irReducer.ts";
-import { addNode as addNodeReducer, type AddableNodeType } from "./addNode.ts";
+import { addNodeAt as addNodeAtReducer, type AddableNodeType } from "./addNode.ts";
+import {
+  graphAtPath,
+  prunePath,
+  resolveFindingPath,
+  updateGraphAtPath,
+} from "./subgraph.ts";
 import {
   connectEdge as connectEdgeReducer,
   deleteEdge as deleteEdgeReducer,
@@ -51,6 +57,14 @@ export interface SelectedEdge {
 
 export interface IRState {
   ir: GraphIR;
+  /**
+   * Workflow node ids from the root down to the sub-graph being edited
+   * (ADR-0050). `[]` = the root. Canvas, palette, Inspector, and SchemaPanel
+   * all operate on the graph at this path; every mutator below retargets its
+   * reducer through `updateGraphAtPath`. Read sites fall back to the root
+   * when the path is transiently invalid (`selectActiveGraph`).
+   */
+  subgraphPath: string[];
   selectedNodeId: string | null;
   selectedEdge: SelectedEdge | null;
   /**
@@ -64,8 +78,28 @@ export interface IRState {
   /**
    * Select a node *and* ask the canvas to center on it (ADR-0043) — the
    * clickable-finding path. Selection semantics match `setSelectedNode`.
+   * The node is looked up in the *active* graph (ADR-0050).
    */
   focusNode: (nodeId: string) => void;
+  /**
+   * Zoom into the sub-graph of a workflow node in the active graph
+   * (ADR-0050): double-click on its canvas card or the Inspector's
+   * "Open sub-graph" button. No-op when the id doesn't name a workflow node
+   * there. Navigation clears both selections — they're scoped to a graph.
+   */
+  enterSubgraph: (workflowNodeId: string) => void;
+  /**
+   * Jump to an arbitrary depth (breadcrumb click). Falls back to the root
+   * when the path doesn't resolve. Clears both selections.
+   */
+  setSubgraphPath: (path: string[]) => void;
+  /**
+   * Navigate to + select + center the node a validator finding points at,
+   * resolving the path-prefixed nested ids ("n_outer/n_inner", ADR-0017).
+   * Falls back to the deepest resolvable prefix; no-op when nothing
+   * resolves. Supersedes `focusNode` for the Preview findings list.
+   */
+  focusFinding: (findingNodeId: string) => void;
   /** Shallow-merge `patch` into the node's `config`, returning a new IR. */
   updateNodeConfig: (nodeId: string, patch: Record<string, unknown>) => void;
   /** Patch one nested `modelParams` key (undefined clears it). */
@@ -82,25 +116,26 @@ export interface IRState {
    */
   setNodePosition: (nodeId: string, x: number, y: number) => void;
   /**
-   * Rename a top-level node and cascade every top-level reference to its old
-   * name (ADR-0036): var-segment `source` in every agent's
-   * `instruction.segments` and every entry of every agent's `config.tools[]`.
-   * Edges are id-keyed and left alone. No-op when the id is unknown or the
-   * name is unchanged. Identifier validity / uniqueness is the validator's
-   * job (invariant 1); Preview surfaces findings honestly.
+   * Rename a node in the active graph and cascade every reference to its old
+   * name across all nesting levels (ADR-0036, ADR-0050): var-segment `source`
+   * in every agent's `instruction.segments` and every entry of every agent's
+   * `config.tools[]`. Edges are id-keyed and left alone. No-op when the id is
+   * unknown or the name is unchanged. Identifier validity / uniqueness is the
+   * validator's job (invariant 1); Preview surfaces findings honestly.
    */
   renameNode: (nodeId: string, newName: string) => void;
   /**
    * Swap the entire IR (used by Load IR — ADR-0024). Clears the selection
-   * because node ids from the loaded IR don't match the previous graph.
+   * and resets `subgraphPath` because node ids from the loaded IR don't
+   * match the previous graph.
    */
   replaceIR: (ir: GraphIR) => void;
   /**
-   * Append a new disconnected node of the given type to the IR (ADR-0025).
-   * Mints a unique id + name across the entire IR (including nested
-   * sub-graphs), selects the new node so the inspector opens on it. The
-   * fresh node is unwired by design; Preview will surface the expected
-   * graph-shape findings until edges land in the next slice.
+   * Append a new disconnected node of the given type to the active graph
+   * (ADR-0025, ADR-0050). Mints a unique id + name across the entire root IR
+   * (including nested sub-graphs), selects the new node so the inspector
+   * opens on it. The fresh node is unwired by design; Preview will surface
+   * the expected graph-shape findings until the user connects it.
    */
   addNode: (type: AddableNodeType, position?: { x: number; y: number }) => void;
   /**
@@ -120,10 +155,10 @@ export interface IRState {
     newRoute: string | undefined,
   ) => void;
   /**
-   * Delete a top-level node and cascade-remove every edge that references it.
-   * Clears `selectedNodeId` if it matched the removed node — selection
-   * lifecycle is a store concern, not part of the pure reducer (ADR-0026).
-   * Also clears `selectedEdge` if it referenced the removed node.
+   * Delete a node from the active graph and cascade-remove every edge that
+   * references it. Clears `selectedNodeId` if it matched the removed node —
+   * selection lifecycle is a store concern, not part of the pure reducer
+   * (ADR-0026). Also clears `selectedEdge` if it referenced the removed node.
    */
   deleteNode: (nodeId: string) => void;
   /**
@@ -134,9 +169,12 @@ export interface IRState {
   /** Append a new schema with one default `field1: str` (ADR-0035). */
   addSchema: () => void;
   /**
-   * Rename a schema and cascade every top-level reference (agent / function /
-   * router / tool / humanInput refs + agent var-chip `schema` fields). No-op
-   * when `newName === oldName` or the schema doesn't exist.
+   * Rename a schema in the active graph and cascade every reference there
+   * (agent / function / router / tool / humanInput refs + agent var-chip
+   * `schema` fields). Active-graph-only is *complete*: schema refs resolve
+   * strictly per-level in the validator, so no cross-level reference can
+   * exist (ADR-0050). No-op when `newName === oldName` or the schema doesn't
+   * exist.
    */
   renameSchema: (oldName: string, newName: string) => void;
   /**
@@ -165,6 +203,7 @@ function edgeMatches(sel: SelectedEdge, from: string, to: string): boolean {
 export function createIRStore(initial: GraphIR): IRStore {
   return create<IRState>((set) => ({
     ir: initial,
+    subgraphPath: [],
     selectedNodeId: null,
     selectedEdge: null,
     focusRequest: null,
@@ -174,6 +213,32 @@ export function createIRStore(initial: GraphIR): IRStore {
         selectedEdge: null,
         focusRequest: { nodeId, nonce: (s.focusRequest?.nonce ?? 0) + 1 },
       })),
+    enterSubgraph: (workflowNodeId) =>
+      set((s) => {
+        const path = [...s.subgraphPath, workflowNodeId];
+        if (!graphAtPath(s.ir, path)) return {};
+        return { subgraphPath: path, selectedNodeId: null, selectedEdge: null };
+      }),
+    setSubgraphPath: (path) =>
+      set((s) => ({
+        subgraphPath: graphAtPath(s.ir, path) ? path : [],
+        selectedNodeId: null,
+        selectedEdge: null,
+      })),
+    focusFinding: (findingNodeId) =>
+      set((s) => {
+        const loc = resolveFindingPath(s.ir, findingNodeId);
+        if (!loc) return {};
+        return {
+          subgraphPath: loc.path,
+          selectedNodeId: loc.nodeId,
+          selectedEdge: null,
+          focusRequest: {
+            nodeId: loc.nodeId,
+            nonce: (s.focusRequest?.nonce ?? 0) + 1,
+          },
+        };
+      }),
     setSelectedNode: (id) =>
       set((s) => ({
         selectedNodeId: id,
@@ -187,24 +252,51 @@ export function createIRStore(initial: GraphIR): IRStore {
         selectedNodeId: edge === null ? s.selectedNodeId : null,
       })),
     updateNodeConfig: (nodeId, patch) =>
-      set((s) => ({ ir: applyNodeConfigPatch(s.ir, nodeId, patch) })),
+      set((s) => ({
+        ir: updateGraphAtPath(s.ir, s.subgraphPath, (g) =>
+          applyNodeConfigPatch(g, nodeId, patch),
+        ),
+      })),
     updateModelParam: (nodeId, key, value) =>
-      set((s) => ({ ir: applyModelParamPatch(s.ir, nodeId, key, value) })),
+      set((s) => ({
+        ir: updateGraphAtPath(s.ir, s.subgraphPath, (g) =>
+          applyModelParamPatch(g, nodeId, key, value),
+        ),
+      })),
     setNodePosition: (nodeId, x, y) =>
-      set((s) => ({ ir: applyNodePosition(s.ir, nodeId, x, y) })),
+      set((s) => ({
+        ir: updateGraphAtPath(s.ir, s.subgraphPath, (g) =>
+          applyNodePosition(g, nodeId, x, y),
+        ),
+      })),
     renameNode: (nodeId, newName) =>
-      set((s) => ({ ir: renameNodeReducer(s.ir, nodeId, newName) })),
-    replaceIR: (ir) => set({ ir, selectedNodeId: null, selectedEdge: null }),
+      set((s) => ({
+        ir: renameNodeAtReducer(s.ir, s.subgraphPath, nodeId, newName),
+      })),
+    replaceIR: (ir) =>
+      set({ ir, subgraphPath: [], selectedNodeId: null, selectedEdge: null }),
     addNode: (type, position) =>
       set((s) => {
-        const { ir, nodeId } = addNodeReducer(s.ir, type, position);
+        const { ir, nodeId } = addNodeAtReducer(
+          s.ir,
+          s.subgraphPath,
+          type,
+          position,
+        );
+        if (ir === s.ir) return {};
         return { ir, selectedNodeId: nodeId, selectedEdge: null };
       }),
     connectEdge: (fromId, toId, route) =>
-      set((s) => ({ ir: connectEdgeReducer(s.ir, fromId, toId, route) })),
+      set((s) => ({
+        ir: updateGraphAtPath(s.ir, s.subgraphPath, (g) =>
+          connectEdgeReducer(g, fromId, toId, route),
+        ),
+      })),
     setEdgeRoute: (fromId, toId, oldRoute, newRoute) =>
       set((s) => {
-        const ir = setEdgeRouteReducer(s.ir, fromId, toId, oldRoute, newRoute);
+        const ir = updateGraphAtPath(s.ir, s.subgraphPath, (g) =>
+          setEdgeRouteReducer(g, fromId, toId, oldRoute, newRoute),
+        );
         // Keep the edge-selection coherent so the dropdown's value follows
         // the relabel without the user re-clicking the edge.
         const sel = s.selectedEdge;
@@ -220,7 +312,9 @@ export function createIRStore(initial: GraphIR): IRStore {
       }),
     deleteNode: (nodeId) =>
       set((s) => {
-        const ir = deleteNodeReducer(s.ir, nodeId);
+        const ir = updateGraphAtPath(s.ir, s.subgraphPath, (g) =>
+          deleteNodeReducer(g, nodeId),
+        );
         const selectedNodeId =
           s.selectedNodeId === nodeId ? null : s.selectedNodeId;
         const selectedEdge =
@@ -228,11 +322,17 @@ export function createIRStore(initial: GraphIR): IRStore {
           (s.selectedEdge.from === nodeId || s.selectedEdge.to === nodeId)
             ? null
             : s.selectedEdge;
-        return { ir, selectedNodeId, selectedEdge };
+        // Defensive: unreachable from the UI (the workflow you're inside is
+        // not in the active graph's nodes), but the dev-window store can
+        // dispatch a delete of an ancestor — don't strand the path.
+        const subgraphPath = prunePath(s.subgraphPath, nodeId) as string[];
+        return { ir, selectedNodeId, selectedEdge, subgraphPath };
       }),
     deleteEdge: (fromId, toId) =>
       set((s) => {
-        const ir = deleteEdgeReducer(s.ir, fromId, toId);
+        const ir = updateGraphAtPath(s.ir, s.subgraphPath, (g) =>
+          deleteEdgeReducer(g, fromId, toId),
+        );
         const selectedEdge =
           s.selectedEdge && edgeMatches(s.selectedEdge, fromId, toId)
             ? null
@@ -240,20 +340,39 @@ export function createIRStore(initial: GraphIR): IRStore {
         return { ir, selectedEdge };
       }),
     addSchema: () =>
-      set((s) => {
-        const { ir } = addSchemaReducer(s.ir);
-        return { ir };
-      }),
+      set((s) => ({
+        ir: updateGraphAtPath(s.ir, s.subgraphPath, (g) => addSchemaReducer(g).ir),
+      })),
     renameSchema: (oldName, newName) =>
-      set((s) => ({ ir: renameSchemaReducer(s.ir, oldName, newName) })),
+      set((s) => ({
+        ir: updateGraphAtPath(s.ir, s.subgraphPath, (g) =>
+          renameSchemaReducer(g, oldName, newName),
+        ),
+      })),
     deleteSchema: (name) =>
-      set((s) => ({ ir: deleteSchemaReducer(s.ir, name) })),
+      set((s) => ({
+        ir: updateGraphAtPath(s.ir, s.subgraphPath, (g) =>
+          deleteSchemaReducer(g, name),
+        ),
+      })),
     addField: (schemaName) =>
-      set((s) => ({ ir: addFieldReducer(s.ir, schemaName) })),
+      set((s) => ({
+        ir: updateGraphAtPath(s.ir, s.subgraphPath, (g) =>
+          addFieldReducer(g, schemaName),
+        ),
+      })),
     updateField: (schemaName, fieldName, patch) =>
-      set((s) => ({ ir: updateFieldReducer(s.ir, schemaName, fieldName, patch) })),
+      set((s) => ({
+        ir: updateGraphAtPath(s.ir, s.subgraphPath, (g) =>
+          updateFieldReducer(g, schemaName, fieldName, patch),
+        ),
+      })),
     deleteField: (schemaName, fieldName) =>
-      set((s) => ({ ir: deleteFieldReducer(s.ir, schemaName, fieldName) })),
+      set((s) => ({
+        ir: updateGraphAtPath(s.ir, s.subgraphPath, (g) =>
+          deleteFieldReducer(g, schemaName, fieldName),
+        ),
+      })),
   }));
 }
 

--- a/apps/web/src/store/schemas.ts
+++ b/apps/web/src/store/schemas.ts
@@ -6,11 +6,12 @@
  * `irEdges.ts`, `insertVariable.ts`: React-free, zustand-free, no `lexical`,
  * IR types consumed type-only (ADR-0011 / ADR-0013 / ADR-0022).
  *
- * Scope: top-level `ir.schemas` only — nested `workflow.config.graph.schemas`
- * are out of scope, consistent with the nested-graph editing deferral across
- * ADR-0017 / ADR-0023 / ADR-0026 / ADR-0029. The UI never re-implements
- * validator rules (identifier validity / uniqueness — invariant 1, type-ref
- * resolution — invariant 5): Preview surfaces those findings honestly.
+ * Scope: one graph's `schemas` at a time. The store retargets these reducers
+ * at the active sub-graph via `updateGraphAtPath` (ADR-0050) — graph-local is
+ * the *complete* scope because the validator resolves schema refs strictly
+ * per-level. The UI never re-implements validator rules (identifier validity
+ * / uniqueness — invariant 1, type-ref resolution — invariant 5): Preview
+ * surfaces those findings honestly.
  */
 import type {
   AgentNode,
@@ -99,9 +100,10 @@ export function addSchema(ir: GraphIR): { ir: GraphIR; schemaName: string } {
  * job (invariant 1) — Preview surfaces INVALID_SCHEMA_NAME /
  * DUPLICATE_SCHEMA_NAME if the user types something illegal.
  *
- * Cascade is top-level only — nested `workflow.config.graph.schemas` are out
- * of scope (consistent with the nested-graph editing deferral throughout the
- * UI). Field-name rename does NOT cascade into chips (see `updateField`).
+ * Cascade covers this graph only, and that is complete: schema refs resolve
+ * strictly per-level in the validator, so a node can never reference another
+ * level's schema (ADR-0050). Field-name rename does NOT cascade into chips
+ * (see `updateField`).
  */
 export function renameSchema(
   ir: GraphIR,

--- a/apps/web/src/store/subgraph.ts
+++ b/apps/web/src/store/subgraph.ts
@@ -1,0 +1,154 @@
+/**
+ * Pure helpers for navigating and editing nested workflow sub-graphs
+ * (ADR-0050). A "subgraph path" is the list of workflow node ids from the
+ * root IR down to the graph being edited — `[]` means the root itself.
+ *
+ * Mutations are **path-scoped** on purpose: node ids are only conventionally
+ * global (`DUPLICATE_NODE_ID` is per-graph, see the note in `addNode.ts`), so
+ * a hand-loaded IR may legally reuse an id across levels. Resolving a path
+ * segment-by-segment is the only id lookup that cannot land on the wrong
+ * node.
+ *
+ * React-free, zustand-free, DOM-free — joins the ADR-0022 reducer family and
+ * is exercised under `node --test` from a cold checkout.
+ */
+import type { GraphIR, WorkflowNode } from "@graphical-agents/ir";
+
+function workflowAt(g: GraphIR, id: string): WorkflowNode | undefined {
+  return g.nodes.find(
+    (n): n is WorkflowNode => n.id === id && n.type === "workflow",
+  );
+}
+
+/**
+ * The GraphIR at `path`. `[]` returns `ir` itself (same reference). Returns
+ * the existing nested object — zero allocation, so zustand selectors built
+ * on it stay referentially stable across unrelated renders. `undefined`
+ * when any segment is missing or isn't a workflow node.
+ */
+export function graphAtPath(
+  ir: GraphIR,
+  path: readonly string[],
+): GraphIR | undefined {
+  let g: GraphIR = ir;
+  for (const seg of path) {
+    const wf = workflowAt(g, seg);
+    if (!wf || wf.config.graph === null || typeof wf.config.graph !== "object") {
+      return undefined;
+    }
+    g = wf.config.graph;
+  }
+  return g;
+}
+
+/**
+ * Immutably replace the graph at `path` with `fn(graph)`. Returns the SAME
+ * `ir` reference when the path is invalid or `fn` returns its input
+ * unchanged (the no-op short-circuit convention of `irEdges.ts`). Only the
+ * spine is rebuilt: ancestor workflow nodes along the path get new objects;
+ * sibling nodes keep referential identity so React Flow doesn't re-render
+ * unrelated cards.
+ */
+export function updateGraphAtPath(
+  ir: GraphIR,
+  path: readonly string[],
+  fn: (g: GraphIR) => GraphIR,
+): GraphIR {
+  if (path.length === 0) return fn(ir);
+  const [head, ...rest] = path;
+  const wf = workflowAt(ir, head);
+  if (!wf) return ir;
+  const nextSub = updateGraphAtPath(wf.config.graph, rest, fn);
+  if (nextSub === wf.config.graph) return ir;
+  const nodes = ir.nodes.map((n) =>
+    n === wf
+      ? { ...wf, config: { ...wf.config, graph: nextSub } }
+      : n,
+  );
+  return { ...ir, nodes };
+}
+
+/**
+ * Breadcrumb items for the workflow nodes along `path` (the root segment is
+ * not included — it renders from `ir.name`). `undefined` when the path is
+ * invalid.
+ */
+export function breadcrumbItems(
+  ir: GraphIR,
+  path: readonly string[],
+): Array<{ id: string; name: string }> | undefined {
+  const out: Array<{ id: string; name: string }> = [];
+  let g: GraphIR = ir;
+  for (const seg of path) {
+    const wf = workflowAt(g, seg);
+    if (!wf) return undefined;
+    out.push({ id: wf.id, name: wf.name });
+    g = wf.config.graph;
+  }
+  return out;
+}
+
+/**
+ * Truncate `path` at the first occurrence of `deletedId` (defensive: a
+ * dev-window dispatch could delete an ancestor workflow node out from under
+ * the active path). Same array reference when nothing matched.
+ */
+export function prunePath(
+  path: readonly string[],
+  deletedId: string,
+): readonly string[] {
+  const i = path.indexOf(deletedId);
+  return i === -1 ? path : path.slice(0, i);
+}
+
+/**
+ * Resolve a validator finding `nodeId` ("n_outer/n_inner/...", the
+ * `pathPrefix` convention of ADR-0017) to a navigable location: every prefix
+ * segment must be a workflow node in successive graphs; the final segment
+ * must be a node in the graph it lands in. When only a prefix resolves,
+ * falls back to the deepest valid location (the enclosing workflow node) —
+ * the recursive analog of `findingTarget.ts`'s top-level fallback. `null`
+ * when nothing resolves.
+ */
+export function resolveFindingPath(
+  ir: GraphIR,
+  findingNodeId: string | undefined,
+): { path: string[]; nodeId: string } | null {
+  if (!findingNodeId) return null;
+  const segs = findingNodeId.split("/");
+  const path: string[] = [];
+  let g: GraphIR = ir;
+  for (let i = 0; i < segs.length; i++) {
+    const seg = segs[i];
+    const isLast = i === segs.length - 1;
+    if (isLast && g.nodes.some((n) => n.id === seg)) {
+      return { path, nodeId: seg };
+    }
+    const wf = workflowAt(g, seg);
+    if (!wf) {
+      // Fall back to the deepest workflow node we resolved into: select the
+      // segment we're currently *inside* (the last entry of `path`) at its
+      // parent path.
+      if (path.length === 0) return null;
+      const nodeId = path[path.length - 1];
+      return { path: path.slice(0, -1), nodeId };
+    }
+    if (isLast) return { path, nodeId: wf.id };
+    path.push(wf.id);
+    g = wf.config.graph;
+  }
+  return null;
+}
+
+/**
+ * Shared selector: the graph the editing surfaces (canvas, palette,
+ * inspector, schema panel) operate on. Falls back to the root when the path
+ * is transiently invalid so a stale path renders the root instead of
+ * crashing.
+ */
+export function selectActiveGraph(s: {
+  ir: GraphIR;
+  subgraphPath: readonly string[];
+}): GraphIR {
+  return graphAtPath(s.ir, s.subgraphPath) ?? s.ir;
+}

--- a/apps/web/src/styles/canvas.css
+++ b/apps/web/src/styles/canvas.css
@@ -125,6 +125,70 @@
   box-shadow: 0 0 0 3px var(--accent-wash);
 }
 
+/* hint shown inside an emptied sub-graph — the example-loading empty state
+   only belongs at the root (ADR-0050) */
+.canvas-empty-subgraph {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+  z-index: 4;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--ink-faint);
+}
+
+/* ------------------------------------------- sub-graph breadcrumb (ADR-0050) */
+
+.subgraph-breadcrumb {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 2px;
+  padding: 5px 12px;
+  border-bottom: 1px solid var(--line);
+  background: var(--paper-raised);
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+}
+.subgraph-breadcrumb__crumb {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+}
+.subgraph-breadcrumb__sep {
+  color: var(--ink-faint);
+  padding: 0 3px;
+}
+.subgraph-breadcrumb__segment {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  font-weight: 500;
+  padding: 2px 6px;
+  border: none;
+  border-radius: var(--r-sm);
+  background: transparent;
+  color: var(--ink-soft);
+}
+button.subgraph-breadcrumb__segment {
+  cursor: pointer;
+  transition: background 0.13s ease, color 0.13s ease;
+}
+button.subgraph-breadcrumb__segment:hover {
+  color: var(--accent-deep);
+  background: var(--accent-wash);
+}
+button.subgraph-breadcrumb__segment:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--accent-wash);
+}
+.subgraph-breadcrumb__segment--current {
+  font-weight: 600;
+  color: var(--ink);
+}
+
 .ir-node {
   --type: var(--ink-faint);
   position: relative;

--- a/apps/web/src/styles/schemas.css
+++ b/apps/web/src/styles/schemas.css
@@ -22,6 +22,20 @@
   color: var(--accent-deep);
   background: var(--accent-wash);
 }
+/* scope caption shown while zoomed into a sub-graph (ADR-0050) */
+.schema-scope {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+}
+.schema-scope strong {
+  color: var(--ink-soft);
+  font-weight: 600;
+  text-transform: none;
+  letter-spacing: normal;
+}
 .schema-empty {
   color: var(--ink-faint);
   font-size: 12px;

--- a/apps/web/test/renameNode.test.ts
+++ b/apps/web/test/renameNode.test.ts
@@ -7,9 +7,9 @@
  * (id-keyed) are left alone. Install-free per ADR-0011 / ADR-0013 / ADR-0022
  * / ADR-0032: only IR types, the validator, codegen, and Node builtins.
  *
- * Top-level only — nested `workflow.config.graph.nodes` rename is out of
- * scope, mirroring the nested-graph editing deferral across
- * ADR-0017 / ADR-0023 / ADR-0026 / ADR-0029 / ADR-0035.
+ * Since ADR-0050 the cascade also recurses into nested
+ * `workflow.config.graph` levels; the nested-specific contracts live in
+ * `subgraphReducers.test.ts`. This suite remains the top-level oracle.
  */
 import { test } from "node:test";
 import assert from "node:assert/strict";

--- a/apps/web/test/subgraph.test.ts
+++ b/apps/web/test/subgraph.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Headless test for the sub-graph navigation helpers (ADR-0050).
+ *
+ * Pins the contracts the zoom-into-sub-graph slice builds on:
+ * (a) `graphAtPath` resolves by reference (zero allocation) and rejects
+ *     missing / non-workflow segments; (b) `updateGraphAtPath` rebuilds only
+ *     the spine, preserves sibling referential identity, and short-circuits
+ *     no-ops to the same root reference; (c) `breadcrumbItems` / `prunePath`
+ *     navigation plumbing; (d) `resolveFindingPath` maps the validator's
+ *     path-prefixed finding ids ("n_outer/n_inner", ADR-0017) to a navigable
+ *     {path, nodeId} with the deepest-valid-prefix fallback.
+ *
+ * Runs under `node --test` against the native TS loader — no `npm install`
+ * (ADR-0011 / ADR-0013), no zustand, no browser.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import type { FunctionNode, GraphIR, WorkflowNode } from "@graphical-agents/ir";
+import {
+  breadcrumbItems,
+  graphAtPath,
+  prunePath,
+  resolveFindingPath,
+  selectActiveGraph,
+  updateGraphAtPath,
+} from "../src/store/subgraph.ts";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const fixturesDir = join(here, "..", "..", "..", "packages", "ir", "fixtures");
+
+function loadNested(): GraphIR {
+  return JSON.parse(
+    readFileSync(join(fixturesDir, "nested.ir.json"), "utf8"),
+  ) as GraphIR;
+}
+
+/** Two-deep IR: root → workflow w1 → workflow w2 → function leaf. */
+function twoDeep(): GraphIR {
+  const leaf: FunctionNode = {
+    id: "n_leaf",
+    type: "function",
+    name: "leaf_fn",
+    config: { description: "", inputType: "str", outputType: "str", emits: "output", body: null },
+  };
+  const w2: WorkflowNode = {
+    id: "n_w2",
+    type: "workflow",
+    name: "wf_inner",
+    config: {
+      graph: {
+        irVersion: "0.1.0",
+        name: "wf_inner",
+        schemas: [],
+        nodes: [leaf],
+        edges: [{ from: "START", to: "n_leaf" }],
+      },
+    },
+  };
+  const w1: WorkflowNode = {
+    id: "n_w1",
+    type: "workflow",
+    name: "wf_outer",
+    config: {
+      graph: {
+        irVersion: "0.1.0",
+        name: "wf_outer",
+        schemas: [],
+        nodes: [w2],
+        edges: [{ from: "START", to: "n_w2" }],
+      },
+    },
+  };
+  return {
+    irVersion: "0.1.0",
+    name: "two_deep",
+    schemas: [],
+    nodes: [w1],
+    edges: [{ from: "START", to: "n_w1" }],
+  };
+}
+
+// --- graphAtPath ----------------------------------------------------------
+
+test("graphAtPath([]) returns the root by reference", () => {
+  const ir = loadNested();
+  assert.equal(graphAtPath(ir, []), ir);
+});
+
+test("graphAtPath resolves one level by reference", () => {
+  const ir = loadNested();
+  const wf = ir.nodes.find((n) => n.id === "n_nested") as WorkflowNode;
+  assert.equal(graphAtPath(ir, ["n_nested"]), wf.config.graph);
+});
+
+test("graphAtPath resolves a two-deep path", () => {
+  const ir = twoDeep();
+  const g = graphAtPath(ir, ["n_w1", "n_w2"]);
+  assert.ok(g);
+  assert.equal(g.nodes[0].id, "n_leaf");
+});
+
+test("graphAtPath rejects unknown and non-workflow segments", () => {
+  const ir = loadNested();
+  assert.equal(graphAtPath(ir, ["n_missing"]), undefined);
+  // n_preprocess exists but is a function, not a workflow.
+  assert.equal(graphAtPath(ir, ["n_preprocess"]), undefined);
+  assert.equal(graphAtPath(ir, ["n_nested", "n_inner_a"]), undefined);
+});
+
+// --- updateGraphAtPath ----------------------------------------------------
+
+test("updateGraphAtPath rebuilds the spine, siblings keep identity", () => {
+  const ir = loadNested();
+  const before = JSON.stringify(ir);
+  const sibling = ir.nodes.find((n) => n.id === "n_preprocess");
+  const next = updateGraphAtPath(ir, ["n_nested"], (g) => ({
+    ...g,
+    nodes: g.nodes.filter((n) => n.id !== "n_inner_b"),
+  }));
+
+  assert.notEqual(next, ir, "root is a new object");
+  const nextWf = next.nodes.find((n) => n.id === "n_nested") as WorkflowNode;
+  const prevWf = ir.nodes.find((n) => n.id === "n_nested") as WorkflowNode;
+  assert.notEqual(nextWf, prevWf, "workflow node on the spine is new");
+  assert.equal(nextWf.config.graph.nodes.length, 1);
+  assert.equal(
+    next.nodes.find((n) => n.id === "n_preprocess"),
+    sibling,
+    "sibling keeps referential identity",
+  );
+  assert.equal(next.edges, ir.edges, "root edges array untouched");
+  assert.equal(JSON.stringify(ir), before, "pure: input untouched");
+});
+
+test("updateGraphAtPath two-deep edit rebuilds both spine levels", () => {
+  const ir = twoDeep();
+  const next = updateGraphAtPath(ir, ["n_w1", "n_w2"], (g) => ({
+    ...g,
+    name: "renamed_inner",
+  }));
+  const w1 = next.nodes[0] as WorkflowNode;
+  const w2 = w1.config.graph.nodes[0] as WorkflowNode;
+  assert.equal(w2.config.graph.name, "renamed_inner");
+  // Original untouched at every level.
+  const ow1 = ir.nodes[0] as WorkflowNode;
+  const ow2 = ow1.config.graph.nodes[0] as WorkflowNode;
+  assert.equal(ow2.config.graph.name, "wf_inner");
+});
+
+test("updateGraphAtPath no-ops: invalid path and identity fn return same ref", () => {
+  const ir = loadNested();
+  assert.equal(updateGraphAtPath(ir, ["n_missing"], (g) => ({ ...g })), ir);
+  assert.equal(updateGraphAtPath(ir, ["n_nested"], (g) => g), ir);
+});
+
+// --- breadcrumbItems / prunePath / selectActiveGraph -----------------------
+
+test("breadcrumbItems lists workflow nodes along the path", () => {
+  const ir = twoDeep();
+  assert.deepEqual(breadcrumbItems(ir, ["n_w1", "n_w2"]), [
+    { id: "n_w1", name: "wf_outer" },
+    { id: "n_w2", name: "wf_inner" },
+  ]);
+  assert.deepEqual(breadcrumbItems(ir, []), []);
+  assert.equal(breadcrumbItems(ir, ["n_w1", "nope"]), undefined);
+});
+
+test("prunePath truncates at the deleted id; same ref on miss", () => {
+  const path = ["n_w1", "n_w2"];
+  assert.deepEqual(prunePath(path, "n_w1"), []);
+  assert.deepEqual(prunePath(path, "n_w2"), ["n_w1"]);
+  assert.equal(prunePath(path, "n_other"), path);
+});
+
+test("selectActiveGraph falls back to root on an invalid path", () => {
+  const ir = loadNested();
+  const wf = ir.nodes.find((n) => n.id === "n_nested") as WorkflowNode;
+  assert.equal(selectActiveGraph({ ir, subgraphPath: ["n_nested"] }), wf.config.graph);
+  assert.equal(selectActiveGraph({ ir, subgraphPath: ["gone"] }), ir);
+});
+
+// --- resolveFindingPath ----------------------------------------------------
+
+test("resolveFindingPath: top-level id resolves at the root path", () => {
+  const ir = loadNested();
+  assert.deepEqual(resolveFindingPath(ir, "n_preprocess"), {
+    path: [],
+    nodeId: "n_preprocess",
+  });
+  // A workflow node's own finding selects it at the root, not inside it.
+  assert.deepEqual(resolveFindingPath(ir, "n_nested"), {
+    path: [],
+    nodeId: "n_nested",
+  });
+});
+
+test("resolveFindingPath: nested finding zooms into the owning sub-graph", () => {
+  const ir = loadNested();
+  assert.deepEqual(resolveFindingPath(ir, "n_nested/n_inner_a"), {
+    path: ["n_nested"],
+    nodeId: "n_inner_a",
+  });
+  const deep = twoDeep();
+  assert.deepEqual(resolveFindingPath(deep, "n_w1/n_w2/n_leaf"), {
+    path: ["n_w1", "n_w2"],
+    nodeId: "n_leaf",
+  });
+});
+
+test("resolveFindingPath: prefix-only ids fall back to the deepest valid location", () => {
+  const ir = loadNested();
+  // The inner id is gone (stale finding) → land on the enclosing workflow.
+  assert.deepEqual(resolveFindingPath(ir, "n_nested/n_gone"), {
+    path: [],
+    nodeId: "n_nested",
+  });
+  const deep = twoDeep();
+  assert.deepEqual(resolveFindingPath(deep, "n_w1/n_w2/n_gone"), {
+    path: ["n_w1"],
+    nodeId: "n_w2",
+  });
+});
+
+test("resolveFindingPath: unresolvable ids return null", () => {
+  const ir = loadNested();
+  assert.equal(resolveFindingPath(ir, "n_gone"), null);
+  assert.equal(resolveFindingPath(ir, "n_gone/n_inner_a"), null);
+  assert.equal(resolveFindingPath(ir, undefined), null);
+});

--- a/apps/web/test/subgraphReducers.test.ts
+++ b/apps/web/test/subgraphReducers.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Headless test for path-scoped editing of nested workflow sub-graphs
+ * (ADR-0050).
+ *
+ * Pins the two genuinely-global reducers and the wrap-don't-rewrite
+ * retargeting pattern: (a) `addNodeAt` mints ids/names against the ROOT's
+ * flat namespace (ADR-0017) but inserts into the graph at the path, and the
+ * result still validates with only the expected fresh-node findings at a
+ * path-prefixed location; (b) `renameNodeAt` renames path-scoped and
+ * cascades agent var-sources / `tools[]` across every nesting level;
+ * (c) the graph-local reducers (`irEdges.ts`, `schemas.ts`) retarget cleanly
+ * through `updateGraphAtPath` with root arrays keeping referential identity.
+ *
+ * Runs under `node --test` against the native TS loader — no `npm install`
+ * (ADR-0011 / ADR-0013), no zustand, no browser.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import type {
+  AgentNode,
+  FunctionNode,
+  GraphIR,
+  WorkflowNode,
+} from "@graphical-agents/ir";
+import { validate } from "../../../packages/ir/src/validate.ts";
+import { addNode, addNodeAt } from "../src/store/addNode.ts";
+import { renameNodeAt } from "../src/store/irReducer.ts";
+import { connectEdge, deleteEdge, deleteNode } from "../src/store/irEdges.ts";
+import { renameSchema } from "../src/store/schemas.ts";
+import { graphAtPath, updateGraphAtPath } from "../src/store/subgraph.ts";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const fixturesDir = join(here, "..", "..", "..", "packages", "ir", "fixtures");
+
+function loadNested(): GraphIR {
+  return JSON.parse(
+    readFileSync(join(fixturesDir, "nested.ir.json"), "utf8"),
+  ) as GraphIR;
+}
+
+function subgraphOf(ir: GraphIR, id: string): GraphIR {
+  return (ir.nodes.find((n) => n.id === id) as WorkflowNode).config.graph;
+}
+
+// --- addNodeAt -------------------------------------------------------------
+
+test("addNodeAt inserts into the sub-graph only; name minted against the root", () => {
+  // Add a function at the root first so it claims `function_1`; the nested
+  // add must see it through the flat global namespace and mint `function_2`.
+  const { ir: withRootFn } = addNode(loadNested(), "function");
+  const rootFn = withRootFn.nodes[withRootFn.nodes.length - 1];
+  assert.equal(rootFn.name, "function_1");
+
+  const { ir, nodeId } = addNodeAt(withRootFn, ["n_nested"], "function");
+  assert.notEqual(nodeId, "");
+  assert.equal(ir.nodes.length, withRootFn.nodes.length, "root node count unchanged");
+  const sub = subgraphOf(ir, "n_nested");
+  assert.equal(sub.nodes.length, 3, "sub-graph gained the node");
+  const added = sub.nodes.find((n) => n.id === nodeId)!;
+  assert.equal(added.name, "function_2", "minted against root, not just the sub-graph");
+
+  // Whole IR still validates with only UNREACHABLE_NODE findings, and the
+  // nested one is located with the validator's path prefix (ADR-0017).
+  const result = validate(ir);
+  assert.deepEqual(
+    result.errors.map((f) => f.code).sort(),
+    ["UNREACHABLE_NODE", "UNREACHABLE_NODE"],
+    JSON.stringify(result.errors),
+  );
+  assert.ok(result.errors.some((f) => f.nodeId === `n_nested/${nodeId}`));
+});
+
+test("addNodeAt can add a workflow inside a sub-graph; inner names stay globally unique", () => {
+  const { ir, nodeId } = addNodeAt(loadNested(), ["n_nested"], "workflow");
+  const sub = subgraphOf(ir, "n_nested");
+  const wf = sub.nodes.find((n) => n.id === nodeId) as WorkflowNode;
+  assert.equal(wf.type, "workflow");
+  assert.ok(wf.config.graph.nodes.length === 1, "minimal sub-IR scaffolded");
+
+  const result = validate(ir);
+  assert.deepEqual(
+    result.errors.map((f) => f.code),
+    ["UNREACHABLE_NODE"],
+    JSON.stringify(result.errors),
+  );
+  assert.equal(result.errors[0]!.nodeId, `n_nested/${nodeId}`);
+});
+
+test("addNodeAt no-ops on an invalid path", () => {
+  const ir = loadNested();
+  const res = addNodeAt(ir, ["n_missing"], "function");
+  assert.equal(res.ir, ir);
+  assert.equal(res.nodeId, "");
+});
+
+// --- renameNodeAt ----------------------------------------------------------
+
+/** nested.ir.json + a root agent using the inner producer as a tool and a
+ *  nested agent whose var chip sources the inner producer. */
+function nestedWithAgents(): GraphIR {
+  const ir = loadNested();
+  const rootAgent: AgentNode = {
+    id: "n_root_agent",
+    type: "agent",
+    name: "root_agent_node",
+    config: {
+      model: "gemini-flash-latest",
+      instruction: { segments: [] },
+      mode: "task",
+      outputSchemaRef: "str",
+      inputSchemaRef: null,
+      tools: ["inner_step_a"],
+    },
+  };
+  const innerAgent: AgentNode = {
+    id: "n_inner_agent",
+    type: "agent",
+    name: "inner_agent_node",
+    config: {
+      model: "gemini-flash-latest",
+      instruction: {
+        segments: [
+          { type: "var", schema: "str", field: "", source: "inner_step_a" },
+        ],
+      },
+      mode: "task",
+      outputSchemaRef: "str",
+      inputSchemaRef: null,
+    },
+  };
+  ir.nodes.push(rootAgent);
+  const sub = subgraphOf(ir, "n_nested");
+  sub.nodes.push(innerAgent);
+  return ir;
+}
+
+test("renameNodeAt renames inside the sub-graph and cascades at every level", () => {
+  const ir = nestedWithAgents();
+  const next = renameNodeAt(ir, ["n_nested"], "n_inner_a", "step_alpha");
+
+  const sub = subgraphOf(next, "n_nested");
+  assert.equal(sub.nodes.find((n) => n.id === "n_inner_a")!.name, "step_alpha");
+  // Root-level tools[] cascade (tools resolve globally by name).
+  const rootAgent = next.nodes.find((n) => n.id === "n_root_agent") as AgentNode;
+  assert.deepEqual(rootAgent.config.tools, ["step_alpha"]);
+  // Same-level var-chip source cascade.
+  const innerAgent = sub.nodes.find((n) => n.id === "n_inner_agent") as AgentNode;
+  const seg = innerAgent.config.instruction.segments[0];
+  assert.equal(seg.type === "var" && seg.source, "step_alpha");
+  // Pure: original untouched.
+  assert.equal(
+    subgraphOf(ir, "n_nested").nodes.find((n) => n.id === "n_inner_a")!.name,
+    "inner_step_a",
+  );
+});
+
+test("renameNodeAt at the root cascades into nested agents", () => {
+  const ir = nestedWithAgents();
+  const sub = subgraphOf(ir, "n_nested");
+  (sub.nodes.find((n) => n.id === "n_inner_agent") as AgentNode).config.tools =
+    ["preprocess"];
+
+  const next = renameNodeAt(ir, [], "n_preprocess", "prepare");
+  assert.equal(next.nodes.find((n) => n.id === "n_preprocess")!.name, "prepare");
+  const innerAgent = subgraphOf(next, "n_nested").nodes.find(
+    (n) => n.id === "n_inner_agent",
+  ) as AgentNode;
+  assert.deepEqual(
+    innerAgent.config.tools,
+    ["prepare"],
+    "previously-deferred recursive cascade now lands",
+  );
+});
+
+test("renameNodeAt no-op contracts return the same reference", () => {
+  const ir = nestedWithAgents();
+  assert.equal(renameNodeAt(ir, ["n_missing"], "n_inner_a", "x"), ir);
+  assert.equal(renameNodeAt(ir, ["n_nested"], "n_gone", "x"), ir);
+  // The id exists at root, not in the sub-graph: path-scoped lookup must miss.
+  assert.equal(renameNodeAt(ir, ["n_nested"], "n_preprocess", "x"), ir);
+  assert.equal(
+    renameNodeAt(ir, ["n_nested"], "n_inner_a", "inner_step_a"),
+    ir,
+  );
+});
+
+// --- graph-local reducers retargeted via updateGraphAtPath ------------------
+
+test("topology reducers wrapped at a path mutate only the sub-graph", () => {
+  const ir = loadNested();
+
+  const connected = updateGraphAtPath(ir, ["n_nested"], (g) =>
+    connectEdge(g, "n_inner_b", "n_inner_a"),
+  );
+  assert.equal(connected.edges, ir.edges, "root edges keep identity");
+  assert.equal(graphAtPath(connected, ["n_nested"])!.edges.length, 3);
+
+  const deletedEdge = updateGraphAtPath(connected, ["n_nested"], (g) =>
+    deleteEdge(g, "n_inner_b", "n_inner_a"),
+  );
+  assert.equal(graphAtPath(deletedEdge, ["n_nested"])!.edges.length, 2);
+
+  const deletedNode = updateGraphAtPath(ir, ["n_nested"], (g) =>
+    deleteNode(g, "n_inner_b"),
+  );
+  const sub = graphAtPath(deletedNode, ["n_nested"])!;
+  assert.equal(sub.nodes.length, 1);
+  assert.equal(sub.edges.length, 1, "cascade removed the inner edge");
+  assert.equal(deletedNode.nodes.length, 3, "root nodes untouched");
+  // deleteNode of a root id inside the sub-graph is a no-op → same root ref.
+  assert.equal(
+    updateGraphAtPath(ir, ["n_nested"], (g) => deleteNode(g, "n_preprocess")),
+    ir,
+  );
+});
+
+test("renameSchema wrapped at a path cascades sub-graph refs only", () => {
+  const ir = loadNested();
+  const sub = subgraphOf(ir, "n_nested");
+  sub.schemas.push({ name: "Inner", fields: [{ name: "f", type: "str" }] });
+  (sub.nodes.find((n) => n.id === "n_inner_a") as FunctionNode).config.outputType =
+    "Inner";
+  ir.schemas.push({ name: "Outer", fields: [{ name: "f", type: "str" }] });
+
+  const next = updateGraphAtPath(ir, ["n_nested"], (g) =>
+    renameSchema(g, "Inner", "InnerRenamed"),
+  );
+  const nextSub = subgraphOf(next, "n_nested");
+  assert.equal(nextSub.schemas[0].name, "InnerRenamed");
+  assert.equal(
+    (nextSub.nodes.find((n) => n.id === "n_inner_a") as FunctionNode).config
+      .outputType,
+    "InnerRenamed",
+  );
+  assert.equal(next.schemas, ir.schemas, "root schemas keep identity");
+});

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -2463,3 +2463,56 @@ hate groups). That story lived nowhere user-facing.
   the intent ("built to be free for…") without claiming a usage restriction.
 **Verify.** `npm test` (tier-1 gate, unaffected but must stay green); `apps/web` type-check —
 the change is presentational JSX/CSS only.
+
+## ADR-0050 — Nested workflow editing: zoom-into-sub-graph via `subgraphPath`
+**Context.** Workflow nodes carry a complete inline sub-IR (`config.graph`, ADR-0017), but
+every editing surface was top-level only — a deferral threaded through ADR-0023 / 0026 /
+0029 / 0035 and pinned in `WorkflowForm`'s "sub-graph editing in a later slice" hint. The
+validator, codegen, and `addNode`'s global name minting already handled arbitrary nesting;
+only the UI lacked a way in.
+**Decisions.**
+- **Navigation model: `subgraphPath: string[]` in the IR store** — workflow node ids,
+  root→current, `[]` = root. Three ways to navigate: double-click a workflow card on the
+  canvas, the Inspector's "Open sub-graph" button, and a breadcrumb bar above the canvas
+  (root segment = `ir.name`, ancestor segments clickable, current segment inert).
+  Navigation clears both selections (they're scoped to a graph); `replaceIR` resets the
+  path (loaded ids don't match, same reasoning as the existing selection clear); read
+  sites fall back to the root on a transiently invalid path (`selectActiveGraph`);
+  `deleteNode` prunes the path defensively (`prunePath` — unreachable from the UI, but the
+  dev-window store can delete an ancestor).
+- **New pure module `store/subgraph.ts`** (`graphAtPath` / `updateGraphAtPath` /
+  `breadcrumbItems` / `prunePath` / `resolveFindingPath` / `selectActiveGraph`), joining
+  the ADR-0022 reducer family. Every existing reducer is **retargeted by wrapping, not
+  rewriting**: store mutators apply their graph-local reducer via
+  `updateGraphAtPath(s.ir, s.subgraphPath, …)`. Mutations are *path-scoped*, never
+  "search the tree for this id" — node ids are only conventionally global
+  (`DUPLICATE_NODE_ID` is per-graph), so a hand-loaded IR may legally reuse an id across
+  levels and a tree search could land on the wrong node.
+- **Two reducers are genuinely global.** `addNodeAt` mints id + name against the **root**
+  (flat namespace, ADR-0017; `collectAllIds`/`collectAllNames` already recurse) but
+  inserts at the path and staggers the default position against the target graph.
+  `renameNodeAt` renames path-scoped, then cascades agent var-sources and `tools[]`
+  across **all** levels — safe because names are globally unique, necessary because
+  `tools[]` resolve globally by name (var sources are per-level, so the superset cascade
+  is correct for both). Behavior change: a root-level `renameNode` now also cascades into
+  nested graphs (previously deferred). `renameSchema` stays active-graph-only and that is
+  *complete*: the validator resolves schema refs strictly per-level, so no cross-level
+  schema reference can exist.
+- **All editing surfaces project the active graph.** Canvas (sub-graphs carry their own
+  START edges and `ui` positions, so the synthetic-START projection works unchanged at
+  any depth), Inspector (`pickNode` + the 6 schema-ref dropdowns + EdgeForm),
+  VariablePalette (matches the validator's per-level var-source scoping), and SchemaPanel
+  (with a "schemas of <name>" scope caption). The example-loading canvas empty state is
+  gated to the root — its buttons call `replaceIR`; an emptied sub-graph shows a hint
+  instead. Preview still compiles the **root** IR; clicking a path-prefixed finding
+  (`n_outer/n_inner`, ADR-0017) now navigates into the owning sub-graph and centers the
+  node via `focusFinding` + `resolveFindingPath` (deepest-valid-prefix fallback;
+  `findingTarget.ts` kept as the documented top-level resolver). Viewport re-frames with
+  a rAF'd `fitView` on navigation, and the ADR-0043 focus effect retries once on the next
+  frame when the target graph hasn't been ingested by React Flow yet — best-effort, same
+  posture as ADR-0043.
+**Verify.** `npm test` (new `subgraph.test.ts` + `subgraphReducers.test.ts`; existing
+reducer oracles green via the `addNode`/`renameNode` compatibility wrappers); manual:
+load the `nested` example, double-click `nested_workflow`, add/connect/rename nodes and
+edit schemas inside it, breadcrumb back out, export — the generated project reflects the
+nested edits.


### PR DESCRIPTION
Double-click a workflow node (or use the Inspector's "Open sub-graph"
button) to edit its nested graph in place; a breadcrumb bar above the
canvas navigates back out. Works at arbitrary depth.

- New pure module store/subgraph.ts: graphAtPath / updateGraphAtPath /
  breadcrumbItems / prunePath / resolveFindingPath / selectActiveGraph.
  Mutations are path-scoped (node ids are only conventionally global).
- Store gains subgraphPath + enterSubgraph / setSubgraphPath /
  focusFinding; every mutator retargets its existing reducer at the
  active graph via updateGraphAtPath (wrap, don't rewrite).
- addNodeAt mints ids/names against the root's flat namespace
  (ADR-0017) but inserts at the path; renameNodeAt renames path-scoped
  and now cascades var-sources/tools[] across all nesting levels.
- Canvas, Inspector, VariablePalette, and SchemaPanel project the
  active graph (schema refs + var sources resolve per-level in the
  validator). Preview still compiles the root; clicking a path-prefixed
  finding (n_outer/n_inner) zooms into the owning sub-graph.
- New headless suites subgraph.test.ts + subgraphReducers.test.ts;
  existing oracles stay green via addNode/renameNode wrappers.

https://claude.ai/code/session_01N6FXGnRp6XN6USEZMnuneP