### PR TITLE
ci(pages): auto-build and deploy apps/web to GitHub Pages on push to main

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,57 @@
+# Builds the visual builder (apps/web) and publishes it to GitHub Pages on
+# every push to main. Replaces the previous manual "rebuild docs/ and commit"
+# step that let the live site drift behind main (e.g. ADR-0051 shipped but the
+# deployed bundle kept the old validator).
+#
+# ONE-TIME SETUP (repo admin): Settings → Pages → Build and deployment →
+# Source → "GitHub Actions". This supersedes the old "Deploy from a branch
+# → /docs" setting; the committed docs/index.html artifact is no longer the
+# deploy source (the markdown docs under docs/ are unaffected).
+#
+# The build uses vite-plugin-singlefile, so the whole app is one self-contained
+# index.html — no base-path config is needed and it serves correctly at any URL.
+name: Deploy web app to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Least-privilege token plus the OIDC + pages scopes the deploy action needs.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# One in-flight deploy at a time; newer pushes supersede older runs.
+concurrency:
+  group: github-pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24" # ≥23 for the native-TS test gate (CLAUDE.md)
+          cache: npm
+      - run: npm ci
+      # Gate: don't deploy a build that fails validation/codegen/web tests.
+      - run: npm test
+      - run: npm run build:pages # → docs/index.html (single self-contained file)
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Why

The live site at `neo-fetch.github.io` drifted behind `main`: the `docs/` deploy artifact was rebuilt **by hand**, so after ADR-0051 merged, the deployed bundle still shipped the **old validator**. Loading a session-`state` IR showed false `VAR_INPUT_SCHEMA_MISMATCH` errors — the deployed validator didn't understand `via: "state"` and applied the single-schema rail to state chips.

The source on `main` is correct (`npm run check:ir` passes); only the published bundle was stale.

## What

A standard GitHub Pages **Actions** workflow (`.github/workflows/deploy-pages.yml`) that, on every push to `main` (and via manual `workflow_dispatch`):

1. `npm ci`
2. `npm test` — gate so a failing build is never deployed
3. `npm run build:pages` → `docs/index.html` (single self-contained file via `vite-plugin-singlefile`)
4. uploads `docs/` and deploys it with `actions/deploy-pages`

Because the build inlines everything into one `index.html`, there's no base-path concern — it serves correctly at any URL.

## ⚠️ One-time setup required (repo admin)

**Settings → Pages → Build and deployment → Source → "GitHub Actions"**

This supersedes the previous *Deploy from a branch → /docs* setting. The committed `docs/index.html` is no longer the deploy source; the markdown docs under `docs/` are unaffected.

## Verify

After merge + the settings change, the run publishes the current build. Loading a session-`state` IR (e.g. the `Session-state variables` gallery example) will validate cleanly instead of showing the stale `VAR_INPUT_SCHEMA_MISMATCH` errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DYvS6rXYNmRMxVGep8dtsj)_