### PR TITLE
docs(readme): give the LangGraph target equal billing

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 ![Project Screenshot](https://github.com/neo-fetch/draw-your-agents/blob/main/assets/choose.png?raw=true)
 
-A visual builder that compiles drag-and-drop agent graphs into runnable **[Google ADK](https://adk.dev/) (Python, v2.0.0) graph-workflow** projects. Also imports **draw.io** XML diagrams into the same graph.
+A visual builder that compiles drag-and-drop agent graphs into runnable Python projects for **two targets from one canonical graph** — **[Google ADK](https://adk.dev/) (v2.0.0) graph-workflows** and **[LangGraph](https://langchain-ai.github.io/langgraph/) (1.x)**. Also imports **draw.io** XML diagrams into the same graph.
 
 Runs entirely in your browser — free for individuals and non-profits, by design. The dark theme, and the ethos behind the whole project, is a tribute to **Bathory** ([why?](#-why-bathory)).
 
-> **Status:** Phase 0 (headless codegen) ✅ — Phase 1 (visual builder) ✅ — Phase 2 (variable chips + schema editor) ✅ — Critic/reviser **loop node**, **nested pydantic models**, **editable node names** ✅ — draw.io import 🔜
+> **Status:** Phase 0 (headless codegen) ✅ — Phase 1 (visual builder) ✅ — Phase 2 (variable chips + schema editor) ✅ — Critic/reviser **loop node**, **nested pydantic models**, **editable node names** ✅ — **LangGraph codegen target** ✅ — **non-adjacent session-`state` variables** ✅ — draw.io import 🔜
 
 ---
 
@@ -17,29 +17,32 @@ Runs entirely in your browser — free for individuals and non-profits, by desig
 - **Drag-and-drop canvas** — Drag node types from the palette onto a React Flow canvas (drops at the cursor), then connect and freely arrange them
 - **Editable node names** — Rename any node in place; references (prompt-variable sources, tool lists) cascade automatically
 - **Full config inspector** — Edit every node property (model, instruction, schemas, routes, tools, etc.) with type-dispatched forms
-- **Live code preview** — See the generated ADK Python project update in real time as you edit the graph
-- **One-click export** — Download a runnable `.zip` project scaffold ready for `pip install && python -m workflow`
+- **Two codegen targets, one graph** — Compile the same IR to a **Google ADK** project (default) or a **LangGraph** project; switch targets on the landing page or via the CLI ([ADR-0045 / ADR-0046](docs/DECISIONS.md))
+- **Live code preview** — See the generated Python project — **ADK or LangGraph** — update in real time as you edit the graph
+- **One-click export** — Download a runnable `.zip` project scaffold (either target) ready to `pip install -r requirements.txt` and run
 - **"Drafting Table" UI** — A distinctive vellum-and-ink design: blueprint canvas grid, per-type color-coding, at-a-glance graph-validity pill
 ![Project Screenshot](https://github.com/neo-fetch/draw-your-agents/blob/main/assets/workflow.png?raw=true)
 
 ### Variable-Chip System (Phase 2 — Headline Feature)
 - **Inline prompt variables** — Drag schema fields into an agent's prompt as chips rendered `<Schema.field from node>`
 - **Auto-wiring** — Inserting a chip automatically sets the agent's `inputSchemaRef`
-- **Single-schema rail** — The palette intelligently filters to one schema per agent, enforcing ADK's data-flow constraints
+- **Single-schema rail** — The palette filters to one schema per agent, enforcing the positional data-flow constraint
+- **Non-adjacent session-`state` variables** — A second chip category (`{Schema.field}`) reads a field from **any upstream ancestor**, not just the immediate node — no re-threading through every intermediate schema ([ADR-0051](docs/DECISIONS.md))
 - **Schema CRUD** — Create, rename, and delete schemas and fields directly in the UI; references cascade on rename
 - **Nested pydantic models** — A schema field's type can be another declared schema (`customer: Customer`); the validator rejects cycles and codegen emits the models in dependency order
 ![Project Screenshot](https://github.com/neo-fetch/draw-your-agents/blob/main/assets/sc%200.png?raw=true)
 
 ### Iterative Refinement — Critic/Reviser Loop
 - **Loop node** — A self-contained *generate → critique → revise* loop that iterates until an LLM critic approves (or a max-iteration cap)
-- **Compiles to a real ADK dynamic workflow** — Codegen emits an `@node` orchestrator (`ctx.run_node` + a bounded Python loop) modeled on a verified working example, placed as one node so the outer graph stays an acyclic DAG
+- **Compiles to a real dynamic workflow** — On ADK, codegen emits an `@node` orchestrator (`ctx.run_node` + a bounded Python loop) modeled on a verified working example; on LangGraph, the equivalent bounded loop runs inside one node function — either way it's one node, so the outer graph stays an acyclic DAG
 - **Typed payloads** — Generator/critic/reviser exchange pydantic-typed I/O (composes with nested schemas); a canonical `{status, feedback}` critic output drives termination
 ![Project Screenshot](https://github.com/neo-fetch/draw-your-agents/blob/main/assets/sc%201.png?raw=true)
 
 ### Code Generation Pipeline
 - **Full v1 declarative coverage** — Agent, Function, Router, JoinNode, HumanInput, nested Workflow, and Tool nodes all compile end to end
-- **Proven against real ADK** — Every generated project constructs successfully against `google-adk==2.0.0` ([ADR-0021](docs/DECISIONS.md))
-- **Golden-file tested** — The codegen output is pinned by golden files; the validator is the IR spec
+- **Two targets from one IR** — A single `compile(ir, { target })` emits a **Google ADK** project (default) or a **LangGraph** project (`target: "langgraph"`), via target dispatch at compile time ([ADR-0045 / ADR-0046](docs/DECISIONS.md))
+- **Proven against both frameworks** — ADK projects construct successfully against `google-adk==2.0.0` ([ADR-0021](docs/DECISIONS.md)); LangGraph projects build and dry-run against `langgraph` 1.x
+- **Golden-file tested** — The codegen output is pinned by golden files **per target** (`golden/` for ADK, `golden-langgraph/` for LangGraph); the validator is the IR spec
 
 ### Graph IR — The Single Source of Truth
 - **One canonical IR** — Every input (visual builder, draw.io) produces a versioned JSON Graph IR. Validation, codegen, and save/load all operate on the IR — never directly on UI state or XML ([ADR-0001](docs/DECISIONS.md))
@@ -51,7 +54,8 @@ Runs entirely in your browser — free for individuals and non-profits, by desig
 ## 🏗 Architecture
 
 ```
-UI / draw.io  →  IR  →  validator  →  codegen  →  runnable ADK project (.zip)
+UI / draw.io  →  IR  →  validator  →  codegen  →  runnable ADK *or* LangGraph project (.zip)
+                                          └── target: "adk" (default) | "langgraph"
 ```
 
 ### Code Generation Pipeline (detailed)
@@ -61,6 +65,8 @@ IR → edges compiler → per-node template fragments → assemble modules
 ```
 
 ### Generated Output (a runnable project, not one file)
+
+**ADK target** (`target: "adk"`, default):
 ```
 my_workflow/
   workflow.py        # root_agent = Workflow(edges=[...])
@@ -68,23 +74,42 @@ my_workflow/
   functions.py       # function / router / join / humanInput bodies
   loops.py           # @node critic/reviser orchestrators (emitted when loop nodes exist)
   schemas.py         # Pydantic BaseModels for every input/output schema
+  main.py            # runnable entrypoint
   requirements.txt   # google-adk==2.0.0
+  .env.example
+  README.md
+```
+
+**LangGraph target** (`target: "langgraph"`):
+```
+my_workflow/
+  graph.py           # StateGraph wiring (nodes, edges, conditional edges, subgraphs)
+  state.py           # TypedDict session state — one <node>_output key per node
+  agents.py          # node fns: init_chat_model(...).with_structured_output(Schema)
+  nodes.py           # function / router / join / humanInput node fns
+  loops.py           # bounded generate→critic→revise loop fns (when loop nodes exist)
+  schemas.py         # shared Pydantic BaseModels
+  main.py            # runnable entrypoint
+  test_graph.py      # builds every StateGraph (dry-run import check)
+  requirements.txt   # langgraph, langchain, langchain-google-genai
   .env.example
   README.md
 ```
 
 ### Node Taxonomy
 
-| IR `type`     | ADK construct        | Key config                                       |
-|---------------|----------------------|--------------------------------------------------|
-| `agent`       | `Agent` / `LlmAgent` | model, instruction (structured template), modelParams, mode, tools, schemas |
-| `function`    | `def f(node_input)`  | description, inputType, outputType, emits, body   |
-| `router`      | fn → `Event(route=)` | routes[], body; branch targets via edge `route`    |
-| `tool`        | `FunctionTool`       | inputType, outputType, body                       |
-| `join`        | `JoinNode`           | waits for all upstreams                           |
-| `humanInput`  | `RequestInput`       | message, payloadRef, responseSchemaRef            |
-| `workflow`    | nested `Workflow`    | sub-IR in `config.graph`                          |
-| `loop`        | `@node` orchestrator | maxIterations, approvalPhrase, input/payload types, generator + critic + reviser sub-agents |
+| IR `type`     | ADK construct        | LangGraph construct                       | Key config                                       |
+|---------------|----------------------|-------------------------------------------|--------------------------------------------------|
+| `agent`       | `Agent` / `LlmAgent` | `init_chat_model().with_structured_output()` node fn | model, instruction (structured template), modelParams, mode, tools, schemas |
+| `function`    | `def f(node_input)`  | node fn → state update                     | description, inputType, outputType, emits, body   |
+| `router`      | fn → `Event(route=)` | node fn + `add_conditional_edges`          | routes[], body; branch targets via edge `route`    |
+| `tool`        | `FunctionTool`       | node fn (pipeline step)                    | inputType, outputType, body                       |
+| `join`        | `JoinNode`           | node fn with `defer=True`                  | waits for all upstreams                           |
+| `humanInput`  | `RequestInput`       | `interrupt()` + `Command(resume=...)`      | message, payloadRef, responseSchemaRef            |
+| `workflow`    | nested `Workflow`    | compiled subgraph                          | sub-IR in `config.graph`                          |
+| `loop`        | `@node` orchestrator | bounded loop in one node fn                | maxIterations, approvalPhrase, input/payload types, generator + critic + reviser sub-agents |
+
+> **Data flow.** ADK threads each node's `Event(output=...)` to the next node's `node_input` (positional); LangGraph writes every node's output to a shared `state` TypedDict (`<node>_output`). Both honor the same IR: positional prompt chips render `<Schema.field from node>` (ADK) / a state read (LangGraph), and non-adjacent `{Schema.field}` chips read from session state in either target.
 
 ---
 
@@ -101,18 +126,20 @@ graphical-agents/
 │   │   ├── fixtures/          # Worked-example IR files (city-time, routing, parallel, etc.)
 │   │   └── test/              # Validator spec tests
 │   │
-│   └── codegen/               # IR → ADK project generator
+│   └── codegen/               # IR → ADK + LangGraph project generators
 │       ├── src/
 │       │   ├── edges.ts       # Edges compiler (linearizes the graph into ADK edge rows)
-│       │   ├── fragments.ts   # Per-node template fragments (renderAgent, renderFunction, etc.)
-│       │   ├── project.ts     # Project assembler (stitches fragments into modules)
-│       │   ├── compile.ts     # validate → generateProject entry point
+│       │   ├── fragments.ts   # Per-node ADK template fragments (renderAgent, renderFunction, etc.)
+│       │   ├── project.ts     # ADK project assembler (stitches fragments into modules)
+│       │   ├── compile.ts     # validate → generateProject entry point (target dispatch)
+│       │   ├── langgraph/     # LangGraph target — state.ts, fragments.ts, graphModule.ts, project.ts
 │       │   ├── format.ts      # Black formatter integration
 │       │   ├── bundle.ts      # Pure-TS STORE-only .zip bundler (browser-compatible)
 │       │   └── python.ts      # Python code generation helpers
 │       └── test/
-│           ├── golden/        # Golden-file test fixtures (the codegen spec)
-│           └── *.test.ts      # Edges, project, compile, format, bundle tests
+│           ├── golden/            # ADK golden-file fixtures (the codegen spec)
+│           ├── golden-langgraph/  # LangGraph golden-file fixtures
+│           └── *.test.ts          # Edges, project, project-langgraph, compile, format, bundle tests
 │
 ├── apps/
 │   └── web/                   # Visual builder — React Flow + Lexical + Zustand
@@ -148,7 +175,7 @@ graphical-agents/
 │
 ├── docs/
 │   ├── ARCHITECTURE.md                # Architecture blueprint
-│   ├── DECISIONS.md                   # Append-only ADR log (ADR-0001 through ADR-0040)
+│   ├── DECISIONS.md                   # Append-only ADR log (ADR-0001 onward)
 │   ├── IR-SCHEMA.md                   # IR contract documentation
 │   ├── PHASE-2-DESIGN.md             # Variable-chip system design
 │   ├── PHASE-NESTED-SCHEMAS-DESIGN.md # Nested pydantic models design
@@ -198,8 +225,11 @@ Opens the visual builder at the Vite dev URL. Load an IR fixture from `packages/
 ### CLI: Compile an IR to a .zip
 
 ```bash
-node scripts/compile.ts packages/ir/fixtures/city-time.ir.json
-# Outputs: city_time_workflow.zip
+# ADK project (default target)
+node scripts/compile.ts packages/ir/fixtures/city-time.ir.json city_time.zip
+
+# LangGraph project
+node scripts/compile.ts packages/ir/fixtures/city-time.ir.json city_time_langgraph.zip --target=langgraph
 ```
 
 ---
@@ -274,7 +304,7 @@ pip install black
 | Package | Role | Dependencies |
 |---------|------|--------------|
 | `packages/ir` | IR types + JSON Schema + validator. **The keystone.** | None |
-| `packages/codegen` | IR → ADK project (templates + edges compiler + golden tests) | `packages/ir` (types only) |
+| `packages/codegen` | IR → ADK **and** LangGraph projects (templates + edges compiler + per-target golden tests) | `packages/ir` (types only) |
 | `apps/web` | React Flow canvas + Lexical prompt editor + Zustand store | `packages/ir` (types), `packages/codegen` (runtime) |
 
 ### Frontend Stack
@@ -333,16 +363,24 @@ The dark theme in this builder is called **bathory**, and it isn't just a color 
 - `Workflow(edges=[...])` where a row is a sequence chain; `("START", ...)` begins a graph; START may repeat (parallel fan-out)
 - Router: a function returns `Event(route=...)` → a row `(router, {route: target})`
 - Data flow is **positional**: `Event(output=...)` → next node's `node_input`. **One output per node.**
-- Agent prompt variables: always emitted in the source-bound form `<Schema.field from node_name>`
+- Agent prompt variables: positional chips emit the source-bound form `<Schema.field from node_name>`; non-adjacent chips emit the session form `{Schema.field}`
 - `JoinNode` waits for all upstreams; every upstream needs a failsafe output or it hangs
 - HumanInput = `RequestInput(message, payload?, response_schema?)`
+
+## 🔗 How the Same IR Maps to LangGraph
+
+- **Shared state, not positional piping** — a `TypedDict` carries one `<node>_output` key per node, plus `workflow_input`; no two nodes (parallel branches included) write the same key, so no reducers are needed
+- **Agents** → lazy `init_chat_model(...)` + `.with_structured_output(Schema)`; **routers** → `add_conditional_edges`; **joins** → a node registered with `defer=True` (LangGraph needs no failsafe outputs)
+- **HumanInput** → `interrupt()` paused on a checkpointer, resumed with `Command(resume=...)`; **loop** nodes → a bounded Python loop inside one node function
+- **Nested workflows** → compiled subgraphs wired into the parent's state
+- See [ADR-0045 / ADR-0046](docs/DECISIONS.md) for the full target design
 
 ---
 
 ## 📄 Documentation
 
 - [Architecture Blueprint](docs/ARCHITECTURE.md) — Full system design
-- [Decision Log (ADRs)](docs/DECISIONS.md) — Append-only architectural decision records (ADR-0001 through ADR-0040)
+- [Decision Log (ADRs)](docs/DECISIONS.md) — Append-only architectural decision records (ADR-0001 onward; LangGraph target: ADR-0045 / ADR-0046)
 - [IR Schema Contract](docs/IR-SCHEMA.md) — Graph IR format specification
 - [Phase 2 Design](docs/PHASE-2-DESIGN.md) — Variable-chip system design & slice plan
 - [Nested Schemas Design](docs/PHASE-NESTED-SCHEMAS-DESIGN.md) — Nested pydantic models design & slice plan


### PR DESCRIPTION
## Why

The README presented the project as **Google ADK–only**, even though codegen has full **LangGraph** parity (ADR-0045/0046) and the UI already lets you pick the target. This brings the docs in line with what the tool actually does.

## What changed

- **Intro & status** — both ADK *and* LangGraph framed as first-class targets from one canonical graph.
- **Features** — added "two codegen targets, one graph"; live preview / export noted as target-agnostic; documented non-adjacent session-`state` variables (ADR-0051).
- **Architecture** — diagram shows the `adk | langgraph` target fork; **Generated Output** now has a block per target (ADK module set *and* the LangGraph `graph.py` / `state.py` / … set).
- **Node Taxonomy** — added a **LangGraph construct** column (agent → `init_chat_model().with_structured_output()`, router → `add_conditional_edges`, join → `defer=True`, humanInput → `interrupt()`, loop → bounded in-node loop, etc.) plus a data-flow note (positional `node_input` vs shared `state` TypedDict).
- **New section** — "How the Same IR Maps to LangGraph".
- **Project structure / CLI / module boundaries** — note `src/langgraph/`, `golden-langgraph/`, and the `--target=langgraph` CLI flag (also fixed the CLI example, which was missing the required out-path).
- Refreshed stale `ADR-0001 through ADR-0040` references.

Docs-only — no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DYvS6rXYNmRMxVGep8dtsj)_